### PR TITLE
[Terraform] Provider & Backend 세팅

### DIFF
--- a/.terraform.lock.hcl
+++ b/.terraform.lock.hcl
@@ -1,0 +1,22 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/google" {
+  version     = "6.0.1"
+  constraints = "~> 6.0.0"
+  hashes = [
+    "h1:yYQNXIaAp7gNCcmPcVMLYyvEmWxaFdIXwW2BYDvf864=",
+    "zh:053bcc0e62396d10a4ef40e59dcdf7d4a1491839e0dfc945de7cef5d9106a566",
+    "zh:282624e6dd086dfe10281f6ad6def3b64279e69fbd667d1141c5f1565e42aecf",
+    "zh:633384cc00d1c6e84b6cb302a898a407c85806a818ca2c93989992b4f9e9af99",
+    "zh:7099aa1a79594c6e041659e36a48f0134a19bd8e1810dfddc21bbad6d3e36d54",
+    "zh:8259adb345c1563a64bdc58efd1cae2ff174b518ccb1f31f79c9c5825e7f762e",
+    "zh:ae2c3008fe93a3bc1318079c23b1da9b55a77ace45f18cf0fa3b2aefcf33e94a",
+    "zh:b7f17cb09b4636edf4aed68ab224885523bd33a0b50af2a2a2819d5a843d49e9",
+    "zh:bee71d0adb8b842b812e4fc76853bedec93c17a6cbf56bc502a2ecf0bcbdaf98",
+    "zh:c187e22fa33cfa90a093cd25e61a77fb88898cce3f79bef33392ddb7708724ca",
+    "zh:dd5923c79697be9429edb98156aa94e69b7258f8de42d8c910dde6814c1ef981",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+    "zh:fe789dc52fc029c18e92db0efb3b013d15679b81c1ab633fa69b3eacde9842ac",
+  ]
+}

--- a/backend.tf
+++ b/backend.tf
@@ -1,0 +1,13 @@
+resource "google_storage_bucket" "tf_state" {
+  project  = var.project
+  name     = "somesup-tfstate"
+  location = var.region
+
+  force_destroy               = false
+  public_access_prevention    = "enforced"
+  uniform_bucket_level_access = true
+
+  versioning {
+    enabled = true
+  }
+}

--- a/provider.tf
+++ b/provider.tf
@@ -1,0 +1,13 @@
+terraform {
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 6.0.0"
+    }
+  }
+
+  backend "gcs" {
+    bucket = "somesup-tfstate"
+    prefix = "terraform/state"
+  }
+}

--- a/variables.tf
+++ b/variables.tf
@@ -1,0 +1,9 @@
+variable "project" {
+  type        = string
+  description = "The name of the project."
+}
+
+variable "region" {
+  type        = string
+  description = "The region to deploy the resources."
+}


### PR DESCRIPTION
# Changelog
- Provider를 GCP로 세팅하였습니다.
- Terraform State를 원격으로 관리하기 위해 `GCS Backend`를 추가하였습니다.

# Testing
N/A