### PR TITLE
[Terraform] MySQL 테이블 컬럼 기본 설정 개선

### DIFF
--- a/src/sql/01_init_db.sql
+++ b/src/sql/01_init_db.sql
@@ -1,14 +1,14 @@
 CREATE DATABASE IF NOT EXISTS somesup;
 
 CREATE TABLE somesup.article_provider (
-  id    INT           NOT NULL,
+  id    INT           NOT NULL AUTO_INCREMENT,
   name  VARCHAR(255)  NOT NULL,
 
   PRIMARY KEY (id)
 );
 
 CREATE TABLE somesup.article (
-  id            INT           NOT NULL,
+  id            INT           NOT NULL AUTO_INCREMENT,
   provider_id   INT           NOT NULL,
   title         VARCHAR(255)  NOT NULL,
   content       TEXT          NOT NULL,
@@ -17,7 +17,7 @@ CREATE TABLE somesup.article (
   section       VARCHAR(30)   NULL,
   thumbnail_url VARCHAR(255)  NOT NULL,
   news_url      VARCHAR(255)  NOT NULL,
-  created_at    DATETIME      NOT NULL,
+  created_at    DATETIME      NOT NULL DEFAULT CURRENT_TIMESTAMP,
 
   PRIMARY KEY (id),
 
@@ -25,14 +25,14 @@ CREATE TABLE somesup.article (
 );
 
 CREATE TABLE somesup.processed_article (
-  id                INT           NOT NULL,
+  id                INT           NOT NULL AUTO_INCREMENT,
   title             VARCHAR(255)  NOT NULL,
   one_line_summary  TEXT          NOT NULL,
   full_summary      TEXT          NOT NULL,
   language          VARCHAR(30)   NOT NULL,
   region            VARCHAR(30)   NULL,
   section           VARCHAR(30)   NULL,
-  created_at        DATETIME      NOT NULL,
+  created_at        DATETIME      NOT NULL DEFAULT CURRENT_TIMESTAMP,
 
   PRIMARY KEY (id)
 );
@@ -40,7 +40,7 @@ CREATE TABLE somesup.processed_article (
 CREATE TABLE somesup.article_processed_mapping (
   article_id    INT           NOT NULL,
   processed_id  INT           NOT NULL,
-  mapped_at     DATETIME      NOT NULL,
+  mapped_at     DATETIME      NOT NULL DEFAULT CURRENT_TIMESTAMP,
 
   FOREIGN KEY (article_id)    REFERENCES article(id),
   FOREIGN KEY (processed_id)  REFERENCES processed_article(id)


### PR DESCRIPTION
# Changelog
- `id`: AUTO INCREMENT 설정
- `created_at`: 기본 값을 CURRENT_TIMESTAMP로 설정

# Testing
Cloud SQL에 적용 완료
<img width="673" alt="image" src="https://github.com/user-attachments/assets/6121f68f-5b19-43e2-a84b-4826f67d010d" />


# Ops Impact
N/A

# Version Compatibility
N/A