### PR TITLE
[Terraform] NewsAPI Fetcher 구현

### DIFF
--- a/news_fetchers.tf
+++ b/news_fetchers.tf
@@ -35,3 +35,32 @@ module "guardian_fetcher" {
     "roles/cloudsql.instanceUser",
   ]
 }
+
+data "google_secret_manager_secret_version" "newsapi_api" {
+  project = var.project
+  secret  = "NEWSAPI_API_KEY"
+}
+
+module "newsapi_fetcher" {
+  source = "./module/cloud_function"
+
+  project_id          = var.project
+  location            = var.region
+  function_name       = "newsapi-fetcher"
+  source_dir          = "${path.module}/src/newsapi_fetcher"
+  source_bucket_name  = google_storage_bucket.cloud_function.name
+  runtime             = "python313"
+  available_memory_mb = "256Mi"
+  entry_point         = "main"
+  environment_variables = {
+    "NEWSAPI_API_KEY"          = data.google_secret_manager_secret_version.newsapi_api.secret_data
+    "INSTANCE_CONNECTION_NAME" = google_sql_database_instance.mysql.connection_name
+    "MYSQL_FETCHER_USERNAME"   = data.google_secret_manager_secret_version.mysql_fetcher_username.secret_data
+    "MYSQL_FETCHER_PASSWORD"   = data.google_secret_manager_secret_version.mysql_fetcher_password.secret_data
+  }
+  roles = [
+    "roles/cloudsql.client",
+    "roles/cloudsql.instanceUser",
+  ]
+
+}

--- a/src/newsapi_fetcher/main.py
+++ b/src/newsapi_fetcher/main.py
@@ -1,0 +1,489 @@
+import dataclasses
+import datetime
+import json
+import logging
+import os
+import sys
+from contextlib import contextmanager
+from typing import Any, Dict, Iterator, Optional, Tuple
+
+import eventregistry
+import functions_framework
+import google.cloud.sql.connector
+import pymysql
+import pymysql.connections
+
+logging.basicConfig(
+    level=logging.INFO,
+    stream=sys.stdout,
+    format='%(levelname)s %(asctime)s %(message)s',
+)
+logger = logging.getLogger(__name__)
+
+
+class Config:
+    """Configuration class for managing environment variables and default values.
+    
+    This class centralizes all configuration parameters required for the news
+    fetching service, including API keys, database connection details, and
+    default values for article fetching.
+    
+    Attributes:
+        NEWSAPI_API_KEY: API key for accessing the News API service.
+        INSTANCE_CONNECTION_NAME: Google Cloud SQL instance connection name.
+        MYSQL_USERNAME: MySQL database username for authentication.
+        MYSQL_PASSWORD: MySQL database password for authentication.
+        MYSQL_DATABASE: Name of the MySQL database to connect to.
+        DEFAULT_NUM_ARTICLES: Default number of articles to fetch per request.
+        DEFAULT_SOURCE_RANK_PERCENTILE: Default source ranking percentile threshold.
+    """
+
+    NEWSAPI_API_KEY = os.getenv("NEWSAPI_API_KEY", '')
+
+    INSTANCE_CONNECTION_NAME = os.getenv("INSTANCE_CONNECTION_NAME", '')
+    MYSQL_USERNAME = os.getenv('MYSQL_FETCHER_USERNAME', '')
+    MYSQL_PASSWORD = os.getenv('MYSQL_FETCHER_PASSWORD', '')
+    MYSQL_DATABASE = 'somesup'
+
+    DEFAULT_NUM_ARTICLES = 5
+    DEFAULT_SOURCE_RANK_PERCENTILE = 10
+
+    def validate(self) -> None:
+        """Validates that all required configuration values are set.
+        
+        Raises:
+            ValueError: If any required environment variable is not set or empty.
+        """
+        if not self.NEWSAPI_API_KEY:
+            raise ValueError("NEWSAPI_API_KEY is not set.")
+        if not self.INSTANCE_CONNECTION_NAME:
+            raise ValueError("INSTANCE_CONNECTION_NAME is not set.")
+        if not self.MYSQL_USERNAME:
+            raise ValueError("MYSQL_FETCHER_USERNAME is not set.")
+        if not self.MYSQL_PASSWORD:
+            raise ValueError("MYSQL_FETCHER_PASSWORD is not set.")
+
+
+@dataclasses.dataclass
+class Article:
+    """Data class representing a news article.
+    
+    This class encapsulates all the essential information about a news article
+    retrieved from the News API, providing a structured way to handle article data
+    throughout the application.
+    
+    Attributes:
+        title: The headline or title of the article.
+        body: The main content/body text of the article.
+        lang: Language code of the article (e.g., 'eng' for English).
+        image: URL of the article's thumbnail or featured image.
+        url: Direct URL link to the original article.
+        source_name: Name of the news source or publication.
+    """
+
+    title: str
+    body: str
+    lang: str
+    image: str
+    url: str
+    source_name: str
+
+    @classmethod
+    def from_api_response(cls, article: Dict[str, Any]) -> 'Article':
+        """Creates an Article instance from API response data.
+        
+        Args:
+            article: Dictionary containing article data from the API response.
+                Expected to contain keys like 'title', 'body', 'lang', 'image',
+                'url', and a nested 'source' dictionary with 'title'.
+        
+        Returns:
+            Article: A new Article instance populated with data from the API response.
+        """
+        source = article.get('source', {})
+        return cls(title=article.get('title', ''),
+                   body=article.get('body', ''),
+                   lang=article.get('lang', 'eng'),
+                   image=article.get('image', ''),
+                   url=article.get('url', ''),
+                   source_name=source.get('title', 'Unknown'))
+
+
+class NewsApiClient:
+    """Client for interacting with the EventRegistry News API.
+    
+    This class provides methods to authenticate with and fetch articles from
+    the EventRegistry API service, handling query construction and response
+    processing.
+    
+    Attributes:
+        _api_key: Private API key for authentication.
+        _er: EventRegistry client instance for making API calls.
+    """
+
+    def __init__(self, api_key: str) -> None:
+        """Initializes the NewsApiClient with the provided API key.
+        
+        Args:
+            api_key: Valid API key for accessing the EventRegistry service.
+            
+        Raises:
+            ValueError: If the API key is empty or None.
+        """
+        if not api_key:
+            raise ValueError("API key must be provided.")
+        self._api_key = api_key
+        self._er = eventregistry.EventRegistry(apiKey=self._api_key)
+
+    def fetch_articles(
+        self,
+        start_date: str,
+        end_date: str,
+        source_rank_percentile: int = 10,
+        num_articles: int = 10,
+    ) -> list[Article]:
+        """Fetches articles from the News API within the specified date range.
+        
+        Args:
+            start_date: Start date for article search in ISO format (YYYY-MM-DD).
+            end_date: End date for article search in ISO format (YYYY-MM-DD).
+            source_rank_percentile: Maximum source ranking percentile to include.
+            num_articles: Maximum number of articles to retrieve.
+        
+        Returns:
+            List of Article objects containing the fetched news articles.
+            Returns an empty list if no articles are found or if an error occurs.
+        """
+        query = {
+            "$query": {
+                "dateStart": start_date,
+                "dateEnd": end_date,
+                "lang": "eng"  # Fix language to English
+            },
+            "$filter": {
+                "startSourceRankPercentile": 0,
+                "endSourceRankPercentile": source_rank_percentile,
+            }
+        }
+        q = eventregistry.QueryArticlesIter.initWithComplexQuery(query)
+        raw_articles = q.execQuery(self._er, maxItems=num_articles)
+
+        return [Article.from_api_response(article) for article in raw_articles]
+
+
+class DatabaseClient:
+    """Client for managing database operations with Google Cloud SQL."""
+
+    def __init__(
+        self,
+        instance_name: str,
+        username: str,
+        password: str,
+        database: str,
+    ) -> None:
+        """Initializes the DatabaseClient with connection parameters."""
+        self._instance_name = instance_name
+        self._username = username
+        self._password = password
+        self._database = database
+
+        self._connector = google.cloud.sql.connector.Connector()
+
+    @contextmanager
+    def get_connection(self) -> Iterator[pymysql.connections.Connection]:
+        """Context manager for database connections.
+        
+        Provides a secure way to manage database connections with automatic
+        cleanup. The connection is automatically closed when exiting the
+        context, even if an exception occurs.
+        
+        Yields:
+            pymysql.connections.Connection: Active database connection.
+            
+        Raises:
+            Exception: Re-raises any database connection errors after logging.
+        """
+        connection = None
+        try:
+            connection = self._connector.connect(
+                self._instance_name,
+                "pymysql",
+                user=self._username,
+                password=self._password,
+                db=self._database,
+            )
+            yield connection
+        except Exception as e:
+            raise e
+        finally:
+            if connection:
+                connection.close()
+
+    def get_or_create_provider(self, provider_name: str) -> int:
+        """Retrieves or creates a news provider record in the database.
+        
+        This method first attempts to find an existing provider with the given name.
+        If no provider is found, it creates a new one and returns the new ID.
+        
+        Args:
+            provider_name: Name of the news provider/source.
+            
+        Returns:
+            int: The database ID of the provider (existing or newly created).
+        """
+        with self.get_connection() as conn:
+            provider_id = self._get_provider_id(conn, provider_name)
+            if provider_id is not None:
+                return provider_id
+
+            return self._create_provider(conn, provider_name)
+
+    def _get_provider_id(
+        self,
+        connection: pymysql.connections.Connection,
+        provider_name: str,
+    ) -> Optional[int]:
+        """Retrieves the ID of an existing provider from the database.
+        
+        Args:
+            connection: Active database connection.
+            provider_name: Name of the provider to search for.
+            
+        Returns:
+            Article Provider ID if found, None otherwise.
+        """
+        with connection.cursor() as cursor:
+            cursor.execute("SELECT id FROM article_provider WHERE name = %s",
+                           (provider_name, ))
+            result = cursor.fetchone()
+            return result[0] if result else None
+
+    def _create_provider(
+        self,
+        connection: pymysql.connections.Connection,
+        provider_name: str,
+    ) -> int:
+        """Creates a new provider record in the database.
+        
+        Args:
+            connection: Active database connection.
+            provider_name: Name of the provider to create.
+            
+        Returns:
+            The Article Provider ID of the newly created provider.
+        """
+        with connection.cursor() as cursor:
+            cursor.execute("INSERT INTO article_provider (name) VALUES (%s)",
+                           (provider_name, ))
+            connection.commit()
+            return cursor.lastrowid
+
+    def check_article_exists(
+        self,
+        provider_id: int,
+        title: str,
+    ) -> bool:
+        """Checks if an article with the given title already exists for a provider.
+        
+        Args:
+            provider_id: Database ID of the article provider.
+            title: Title of the article to check for.
+            
+        Returns:
+            True if the article exists, False otherwise.
+        """
+        with self.get_connection() as conn:
+            with conn.cursor() as cursor:
+                cursor.execute(
+                    "SELECT COUNT(*) FROM article WHERE provider_id = %s AND title = %s",
+                    (provider_id, title))
+                count = cursor.fetchone()[0]
+                return count > 0
+
+    def create_article(
+        self,
+        provider_id: int,
+        article: Article,
+    ) -> bool:
+        """Creates a new article record in the database.
+
+        This method handles duplicate articles gracefully by logging a warning
+        and returning False rather than raising an exception.
+        
+        Args:
+            provider_id: Database ID of the article provider.
+            article: Article object containing the article data to store.
+            
+        Returns:
+            True if the article was successfully created, False otherwise.
+        """
+        with self.get_connection() as conn:
+            with conn.cursor() as cursor:
+                try:
+                    cursor.execute(
+                        "INSERT INTO article (provider_id, title, content, language, thumbnail_url, news_url) "
+                        "VALUES (%s, %s, %s, %s, %s, %s)", (
+                            provider_id,
+                            article.title,
+                            article.body,
+                            article.lang,
+                            article.image,
+                            article.url,
+                        ))
+                    conn.commit()
+                    return True
+                except pymysql.err.IntegrityError as e:
+                    logger.warning("Article already exists: %s", e)
+                    return False
+                except Exception as e:
+                    logger.error("Error inserting article: %s", e)
+                    return False
+
+
+class NewsFetcher:
+    """Orchestrator class for fetching and storing news articles.
+    
+    This class combines the NewsApiClient and DatabaseClient to provide a
+    high-level interface for the complete news fetching workflow, including
+    article retrieval, provider management, and database storage.
+    """
+
+    def __init__(
+        self,
+        newsapi_client: NewsApiClient,
+        db_client: DatabaseClient,
+    ) -> None:
+        """Initializes the NewsFetcher with required client dependencies.
+        
+        Args:
+            newsapi_client: Configured NewsApiClient for article fetching.
+            db_client: Configured DatabaseClient for data persistence.
+        """
+        self._newsapi_client = newsapi_client
+        self._db_client = db_client
+
+    def fetch_and_store(
+        self,
+        fromt_date: datetime.date,
+        to_date: datetime.date,
+        num_articles: int,
+    ) -> Tuple[int, int]:
+        """Fetches articles from API and stores them in the database.
+        
+        This method performs the complete workflow of fetching articles from the
+        News API, managing provider records, checking for duplicates, and storing
+        new articles in the database.
+        
+        Args:
+            fromt_date: Start date for article fetching.
+            to_date: End date for article fetching.
+            num_articles: Maximum number of articles to fetch and process.
+            
+        Returns:
+            A tuple containing (stored_count, total_count)
+                - stored_count: The number of articles successfully stored
+                - total_count: The total number of articles fetched from the API.
+        """
+
+        articles = self._newsapi_client.fetch_articles(
+            start_date=fromt_date.isoformat(),
+            end_date=to_date.isoformat(),
+            num_articles=num_articles,
+        )
+
+        if not articles:
+            logger.warning("No articles found for the given date range.")
+            return 0, 0
+
+        # Cache provider name and ID to avoid redundant database queries
+        provider_cache: dict[str, int] = {}
+        for article in articles:
+            if article.source_name not in provider_cache:
+                provider_id = self._db_client.get_or_create_provider(
+                    article.source_name)
+                provider_cache[article.source_name] = provider_id
+
+        stored_count = 0
+        for article in articles:
+            provider_id = provider_cache.get(article.source_name)
+
+            if provider_id is None:
+                logger.error("Provider ID not found for %s. Skipping article.",
+                             article.source_name)
+                continue
+
+            if self._db_client.check_article_exists(provider_id,
+                                                    article.title):
+                logger.info("Article '%s' already exists. Skipping.",
+                            article.title)
+                continue
+
+            if self._db_client.create_article(provider_id, article):
+                stored_count += 1
+
+        return stored_count, len(articles)
+
+
+@functions_framework.http
+def main(request) -> dict[str, Any]:
+    """Main entry point for the Google Cloud Function.
+    
+    This function serves as the HTTP endpoint for the news fetching service.
+    It initializes the required components, fetches articles from the previous day,
+    and stores them in the database.
+    
+    Args:
+        request: HTTP request object from the Cloud Functions framework.
+            Currently unused but required by the framework interface.
+    
+    Returns:
+        HTTP response dictionary containing:
+            - statusCode: HTTP status code (200 for success, 500 for error)
+            - body: JSON string containing either success data or error message
+            
+        Success response includes:
+            - stored_count: Number of articles successfully stored
+            - total_count: Total number of articles fetched
+            - from_date: Start date of the fetch operation (ISO format)
+            - to_date: End date of the fetch operation (ISO format)
+    """
+
+    try:
+        config = Config()
+        config.validate()
+    except ValueError as e:
+        logger.error("Configuration error: %s", e)
+        return {
+            "statusCode": 500,
+            "body": json.dumps({"error": str(e)}),
+        }
+
+    newsapi_client = NewsApiClient(config.NEWSAPI_API_KEY)
+    db_client = DatabaseClient(
+        instance_name=config.INSTANCE_CONNECTION_NAME,
+        username=config.MYSQL_USERNAME,
+        password=config.MYSQL_PASSWORD,
+        database=config.MYSQL_DATABASE,
+    )
+    news_fetcher = NewsFetcher(newsapi_client, db_client)
+
+    from_date = datetime.date.today() - datetime.timedelta(days=1)
+    to_date = datetime.date.today()
+
+    stored_count, total_count = news_fetcher.fetch_and_store(
+        fromt_date=from_date,
+        to_date=to_date,
+        num_articles=Config.DEFAULT_NUM_ARTICLES,
+    )
+
+    return {
+        "statusCode":
+        200,
+        "body":
+        json.dumps({
+            "stored_count": stored_count,
+            "total_count": total_count,
+            "from_date": from_date.isoformat(),
+            "to_date": to_date.isoformat(),
+        }),
+    }

--- a/src/newsapi_fetcher/requirements.txt
+++ b/src/newsapi_fetcher/requirements.txt
@@ -1,0 +1,4 @@
+functions-framework==3.8.3
+eventregistry==9.1
+PyMySQL==1.1.1
+cloud-sql-python-connector==1.18.1


### PR DESCRIPTION
# Changelog
- `newsapi.ai`에서 기사를 가져와 Cloud SQL에 저장하는 Cloud Function을 구현하였습니다.
  - `newsapi.ai`에는 여러 article provider들의 뉴스가 합쳐져있기 때문에, Article Provider를 확인하고 없으면 생성하는 로직을 추가하였습니다.

# Testing
- Status 200
<img width="952" alt="image" src="https://github.com/user-attachments/assets/6f7efa3e-3103-4f00-a890-202d59b74364" />

- Cloud SQL 데이터 검증
<img width="1319" alt="image" src="https://github.com/user-attachments/assets/8b656aaa-0349-4ce6-8ae5-3a65f86373f1" />

- Article Provider 생성 검증
<img width="316" alt="image" src="https://github.com/user-attachments/assets/9bf5fa33-95ad-40f1-8054-db42ef9403b3" />

# Ops Impact
N/A

# Version Compatibility
N/A