### PR TITLE
[Terraform] Cloud Function 모듈에 outputs 추가

### DIFF
--- a/module/cloud_function/outputs.tf
+++ b/module/cloud_function/outputs.tf
@@ -1,0 +1,24 @@
+output "function_name" {
+  value       = google_cloudfunctions2_function.main.name
+  description = "The name of the deployed Cloud Function."
+}
+
+output "function_location" {
+  value       = google_cloudfunctions2_function.main.location
+  description = "The location where the Cloud Function is deployed."
+}
+
+output "function_url" {
+  value       = google_cloudfunctions2_function.main.service_config[0].uri
+  description = "The HTTPS endpoint of the deployed Cloud Function (if HTTP trigger)."
+}
+
+output "function_state" {
+  value       = google_cloudfunctions2_function.main.state
+  description = "The current state of the Cloud Function."
+}
+
+output "service_account_email" {
+  value       = google_cloudfunctions2_function.main.service_config[0].service_account_email
+  description = "The email of the service account used by the Cloud Function."
+}


### PR DESCRIPTION
# Changelog
- Cloud Function 모듈을 사용하는 경우 Function URL이나 사용중인 Service Account 등에 접근할 필요가 있습니다. 이를 쉽게 하기 위해 `outputs.tf` 파일을 생성하고 중요한 값들을 모듈 외부로 노출시켰습니다.

# Testing
로컬에서 `module.{모듈이름}.function_name`으로 접근 가능한 것을 확인하였습니다.

# Ops Impact
N/A

# Version Compatibility
N/A