### PR TITLE
[Terraform] Summarizer Cloud Function의 최대 인스턴스 개수 증가

### DIFF
--- a/cluster_summarizer.tf
+++ b/cluster_summarizer.tf
@@ -19,6 +19,7 @@ module "cluster_summarizer" {
   runtime             = "python313"
   available_memory_mb = "256Mi"
   entry_point         = "main"
+  max_instance_count  = 20
   environment_variables = {
     PROJECT_ID                = var.project
     VERTEX_AI_REGION          = "us-central1" # Gemini 2.5 is only available in us-central1


### PR DESCRIPTION
# Changelog
- Summarizer는 다량의 뉴스가 동시에 들어오기 때문에 현재 default max instance count인 3개는 부족합니다. 따라서 20개로 증가하였습니다.

# Testing
![image](https://github.com/user-attachments/assets/175682bd-dcd7-408f-982e-62253374e624)

# Ops Impact
N/A

# Version Compatibility
N/A