### PR TITLE
[Terraform] Summarizer를 뉴스 처리 메인 Workflow와 연결

### DIFF
--- a/src/workflows/article_processing.yaml
+++ b/src/workflows/article_processing.yaml
@@ -8,6 +8,8 @@ main:
           - summary_queue_name: ${SUMMARY_QUEUE_NAME}
           - fetcher_urls: ${FETCHER_URLS}
           - clustering_url: ${CLUSTERING_URL}
+          - summarizer_url: ${SUMMARIZER_URL}
+          - workflow_service_account: ${WORKFLOW_SERVICE_ACCOUNT}
           - fetcher_results: []
 
     - fetch_news_articles:
@@ -43,8 +45,25 @@ main:
           index: idx
           in: $${clusters}
           steps:
-            # TODO: Implement the summarize Cloud Function and call it
-            - log_cluster_info:
-                call: sys.log
+            - prepare_task_payload:
+                assign:
+                  - task_payload:
+                      cluster_id: $${idx}
+                      article_ids: $${cluster}
+                  - payload_json: $${json.encode(task_payload)}
+                  - payload_base64: $${base64.encode(payload_json)}
+            - create_task_for_summarizer:
+                call: googleapis.cloudtasks.v2.projects.locations.queues.tasks.create
                 args:
-                  text: $${"Cluster " + string(idx) + " has " + string(len(cluster)) + " items " + json.encode_to_string(cluster)}
+                  parent: $${"projects/" + project + "/locations/" + location + "/queues/" + summary_queue_name}
+                  body:
+                    task:
+                      httpRequest:
+                        httpMethod: POST
+                        url: $${summarizer_url}
+                        headers:
+                          Content-Type: application/json
+                        body: $${payload_base64}
+                        oidcToken:
+                          serviceAccountEmail: $${workflow_service_account}
+                result: task_creation_result


### PR DESCRIPTION
# Changelog
- 기사를 가져와 요약하는 메인 워크플로우인 `article-processing-workflow`에 Summarizer를 연결하였습니다.

# Testing
1. Workflow 실행 결과
![image](https://github.com/user-attachments/assets/952b883d-d3d5-4faf-931b-36dbfd145c84)

![image](https://github.com/user-attachments/assets/13a76839-ed34-4673-aa4a-f7071e4721b5)

2. 데이터베이스의 `article`테이블 확인
![image](https://github.com/user-attachments/assets/4a44c286-9b5c-4ca2-8d16-79f87677b3b0)

3. 데이터베이스의 `processed_article`테이블 확인 (id 1~11은 이전 테스트 때 생성하였던 것들임)
![image](https://github.com/user-attachments/assets/72802ad8-e5e2-438c-84c9-f35642ab31fd)

# Ops Impact
N/A

# Version Compatibility
N/A