### PR TITLE
[Server] 뉴스 조회 API 구현

### DIFF
--- a/server/main.ts
+++ b/server/main.ts
@@ -1,9 +1,14 @@
 import Express from 'express'
 import dotenv from 'dotenv'
 
+import articleRouter from './src/routes/article'
+
 dotenv.config()
 
 const app = Express()
+app.use(Express.json())
+
+app.use('/api/articles', articleRouter)
 
 const PORT = process.env.PORT || 3000
 

--- a/server/src/controllers/articleController.ts
+++ b/server/src/controllers/articleController.ts
@@ -1,0 +1,60 @@
+import { Request, Response } from 'express'
+import { prisma } from '../../prisma/prisma'
+
+/**
+ * 기사 목록을 페이지네이션과 함께 조회합니다.
+ */
+export const getArticles = async (req: Request, res: Response) => {
+  const page = req.query.page ? parseInt(req.query.page as string, 10) : 1
+  const limit = req.query.limit ? parseInt(req.query.limit as string, 10) : 10
+
+  try {
+    const articles = await prisma.processedArticle.findMany({
+      skip: (page - 1) * limit,
+      take: limit,
+      orderBy: {
+        created_at: 'desc',
+      },
+    })
+
+    const totalCount = await prisma.processedArticle.count()
+
+    if (articles.length === 0) {
+      return res.status(404).json({ error: 'No articles found' })
+    }
+
+    res.json({
+      articles,
+      pagination: {
+        page,
+        limit,
+        total: totalCount,
+      },
+    })
+  } catch (error) {
+    console.error(error)
+    res.status(500).json({ error: 'Internal server error' })
+  }
+}
+
+/**
+ * 특정 ID의 기사를 조회합니다.
+ */
+export const getArticleById = async (req: Request, res: Response) => {
+  const id = parseInt(req.params.id, 10)
+
+  try {
+    const article = await prisma.processedArticle.findUnique({
+      where: { id },
+    })
+
+    if (!article) {
+      return res.status(404).json({ error: 'Article not found' })
+    }
+
+    res.json(article)
+  } catch (error) {
+    console.error(error)
+    res.status(500).json({ error: 'Internal server error' })
+  }
+}

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -1,1 +1,0 @@
-console.log("Hello, World!");

--- a/server/src/routes/article.ts
+++ b/server/src/routes/article.ts
@@ -1,0 +1,18 @@
+import { Router } from 'express'
+import { getArticles, getArticleById } from '../controllers/articleController'
+
+const router = Router()
+
+/**
+ * 기사 목록 조회 (페이지네이션)
+ * GET /
+ */
+router.get('/', getArticles)
+
+/**
+ * 특정 기사 조회
+ * GET /:id
+ */
+router.get('/:id', getArticleById)
+
+export default router


### PR DESCRIPTION
# Changelog
- 뉴스 관련 기본 API를 구현하였습니다.
  - `/api/articles`: 페이지네이션 된 여러 개의 뉴스 반환
  - `/api/articles/:id`: 특정 ID의 뉴스 반환

# Testing
로컬에서 테스트
- articles
<img width="992" alt="image" src="https://github.com/user-attachments/assets/764449b6-6707-42d3-8c57-3331a1a08684" />

- article/:id
<img width="1001" alt="image" src="https://github.com/user-attachments/assets/e6404e0b-3901-45b8-a972-82cdd4caf697" />

# Ops Impact
N/A

# Version Compatibility
N/A