### PR TITLE
[Server] 사용자와 Refresh Token의 관계 변경

### DIFF
--- a/server/prisma/migrations/20250706094318_init/migration.sql
+++ b/server/prisma/migrations/20250706094318_init/migration.sql
@@ -77,6 +77,7 @@ CREATE TABLE `refresh_token` (
     `revoked_at` DATETIME(3) NULL,
     `is_revoked` BOOLEAN NOT NULL DEFAULT false,
 
+    UNIQUE INDEX `refresh_token_user_id_key`(`user_id`),
     PRIMARY KEY (`id`)
 ) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
 

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -75,12 +75,14 @@ model KeywordArticleMapping {
 }
 
 model User {
-  id               Int     @id @default(autoincrement())
-  nickname         String  @unique
-  phone            String  @unique
-  is_authenticated Boolean @default(false)
+  id               Int      @id @default(autoincrement())
+  nickname         String   @unique
+  phone            String   @unique
+  is_authenticated Boolean  @default(false)
+  created_at       DateTime @default(now())
+  updated_at       DateTime @updatedAt
 
-  refreshTokens RefreshToken[]
+  refreshTokens RefreshToken?
   likes         Like[]
   scraps        Scrap[]
 
@@ -89,7 +91,7 @@ model User {
 
 model RefreshToken {
   id         Int       @id @default(autoincrement())
-  user_id    Int
+  user_id    Int       @unique
   token      String
   expires_at DateTime
   created_at DateTime  @default(now())


### PR DESCRIPTION
# Changelog
- 사용자가 동시에 최대 한개의 토큰을 가질 수 있도록 관계를 1:1 로 변경하였습니다.
- 사용자 테이블에 `created_at`, `updated_at` 을 추가하였습니다.

# Testing
N/A

# Ops Impact
N/A

# Version Compatibility
N/A