### PR TITLE
[Server] Unit Test 헬퍼 함수 및 Mock Prisma Client 생성

### DIFF
--- a/server/prisma/mock.ts
+++ b/server/prisma/mock.ts
@@ -1,0 +1,16 @@
+import { PrismaClient } from '@prisma/client'
+import { mockDeep, DeepMockProxy, mockReset } from 'jest-mock-extended'
+import { beforeEach } from 'node:test'
+
+import { prisma } from './prisma'
+
+jest.mock('./prisma.ts', () => ({
+  __esModule: true,
+  prisma: mockDeep<PrismaClient>(),
+}))
+
+beforeEach(() => {
+  mockReset(prismaMock)
+})
+
+export const prismaMock = prisma as unknown as DeepMockProxy<PrismaClient>

--- a/server/src/__mocks__/express.ts
+++ b/server/src/__mocks__/express.ts
@@ -1,0 +1,8 @@
+export const mockReq = (body = {}) => ({ body }) as any
+export const mockRes = () => {
+  const res: any = {}
+  res.status = jest.fn().mockReturnValue(res)
+  res.send = jest.fn().mockReturnValue(res)
+  res.json = jest.fn().mockReturnValue(res)
+  return res
+}


### PR DESCRIPTION
# Changelog
- 컨트롤러와 서비스등을 구현하기 전에 Unit Test를 용이하게 작성하기 위해 헬퍼 함수를 정의하였습니다.
- Express의 요청과 응답을 모킹하는 `mockReq`, `mockRes` 를 생성하였습니다.
- Prisma Client를 모킹하는 prismaMock을 생성하였습니다.

# Testing
N/A

# Ops Impact
N/A

# Version Compatibility
N/A