### PR TITLE
[Server] Redis 초기 구성 및 싱글톤 클라이언트 생성

### DIFF
--- a/server/.env.test
+++ b/server/.env.test
@@ -1,0 +1,23 @@
+PORT=3000
+
+# Database Settings
+DB_HOST=test_db_host
+DB_USER=test_db_user
+DB_PASSWORD=test_db_password
+DB_PORT=3306
+DB_NAME=test_db_name
+DATABASE_URL="mysql://${DB_USER}:${DB_PASSWORD}@${DB_HOST}:${DB_PORT}/${DB_NAME}"
+
+# CoolSMS Settings
+COOLSMS_API_KEY=test_coolsms_api_key
+COOLSMS_API_SECRET=test_coolsms_api_secret
+COOLSMS_FROM_PHONE_NUMBER=test_coolsms_from_phone_number
+
+# Redis Settings
+REDIS_URL=redis://test_redis
+
+# JWT Settings
+JWT_SECRET=test_jwt_secret
+JWT_REFRESH_SECRET=test_jwt_refresh_secret
+JWT_EXPIRES_IN=1h
+JWT_REFRESH_EXPIRES_IN=30d

--- a/server/jest.config.ts
+++ b/server/jest.config.ts
@@ -1,4 +1,7 @@
 module.exports = {
+  clearMocks: true,
   preset: 'ts-jest',
   testEnvironment: 'node',
+  setupFilesAfterEnv: ['./prisma/mock.ts'],
+  setupFiles: ['./jest.env.ts'],
 }

--- a/server/jest.env.ts
+++ b/server/jest.env.ts
@@ -1,0 +1,3 @@
+import dotenv from 'dotenv'
+
+dotenv.config({ path: '.env.test' })

--- a/server/package.json
+++ b/server/package.json
@@ -25,6 +25,7 @@
     "@types/node": "^22.7.4",
     "@types/string-hash": "^1.1.3",
     "dotenv": "^16.4.5",
+    "jest-mock-extended": "^4.0.0",
     "node-mocks-http": "^1.17.2",
     "nodemon": "^3.1.10",
     "prettier": "^3.3.3",

--- a/server/pnpm-lock.yaml
+++ b/server/pnpm-lock.yaml
@@ -51,6 +51,9 @@ importers:
       dotenv:
         specifier: ^16.4.5
         version: 16.6.1
+      jest-mock-extended:
+        specifier: ^4.0.0
+        version: 4.0.0(@jest/globals@30.0.4)(jest@30.0.4(@types/node@22.16.0)(ts-node@10.9.2(@types/node@22.16.0)(typescript@5.8.3)))(typescript@5.8.3)
       node-mocks-http:
         specifier: ^1.17.2
         version: 1.17.2(@types/express@4.17.23)(@types/node@22.16.0)
@@ -1279,6 +1282,13 @@ packages:
     resolution: {integrity: sha512-vXywcxmr0SsKXF/bAD7t7nMamRvPuJkras00gqYeB1V0WllxZrbZ0paRr3XqpFU2sYYjD0qAaG2fRyn/CGZ0aw==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
+  jest-mock-extended@4.0.0:
+    resolution: {integrity: sha512-7BZpfuvLam+/HC+NxifIi9b+5VXj/utUDMPUqrDJehGWVuXPtLS9Jqlob2mJLrI/pg2k1S8DMfKDvEB88QNjaQ==}
+    peerDependencies:
+      '@jest/globals': ^28.0.0 || ^29.0.0 || ^30.0.0
+      jest: ^24.0.0 || ^25.0.0 || ^26.0.0 || ^27.0.0 || ^28.0.0 || ^29.0.0 || ^30.0.0
+      typescript: ^3.0.0 || ^4.0.0 || ^5.0.0
+
   jest-mock@30.0.2:
     resolution: {integrity: sha512-PnZOHmqup/9cT/y+pXIVbbi8ID6U1XHRmbvR7MvUy4SLqhCbwpkmXhLbsWbGewHrV5x/1bF7YDjs+x24/QSvFA==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
@@ -1853,6 +1863,14 @@ packages:
 
   tr46@0.0.3:
     resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
+
+  ts-essentials@10.1.1:
+    resolution: {integrity: sha512-4aTB7KLHKmUvkjNj8V+EdnmuVTiECzn3K+zIbRthumvHu+j44x3w63xpfs0JL3NGIzGXqoQ7AV591xHO+XrOTw==}
+    peerDependencies:
+      typescript: '>=4.5.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
 
   ts-jest@29.4.0:
     resolution: {integrity: sha512-d423TJMnJGu80/eSgfQ5w/R+0zFJvdtTxwtF9KzFFunOpSeD+79lHJQIiAhluJoyGRbvj9NZJsl9WjCUo0ND7Q==}
@@ -3434,6 +3452,13 @@ snapshots:
       slash: 3.0.0
       stack-utils: 2.0.6
 
+  jest-mock-extended@4.0.0(@jest/globals@30.0.4)(jest@30.0.4(@types/node@22.16.0)(ts-node@10.9.2(@types/node@22.16.0)(typescript@5.8.3)))(typescript@5.8.3):
+    dependencies:
+      '@jest/globals': 30.0.4
+      jest: 30.0.4(@types/node@22.16.0)(ts-node@10.9.2(@types/node@22.16.0)(typescript@5.8.3))
+      ts-essentials: 10.1.1(typescript@5.8.3)
+      typescript: 5.8.3
+
   jest-mock@30.0.2:
     dependencies:
       '@jest/types': 30.0.1
@@ -4067,6 +4092,10 @@ snapshots:
   touch@3.1.1: {}
 
   tr46@0.0.3: {}
+
+  ts-essentials@10.1.1(typescript@5.8.3):
+    optionalDependencies:
+      typescript: 5.8.3
 
   ts-jest@29.4.0(@babel/core@7.28.0)(@jest/transform@30.0.4)(@jest/types@30.0.1)(babel-jest@30.0.4(@babel/core@7.28.0))(jest-util@30.0.2)(jest@30.0.4(@types/node@22.16.0)(ts-node@10.9.2(@types/node@22.16.0)(typescript@5.8.3)))(typescript@5.8.3):
     dependencies:

--- a/server/src/config/__tests__/redis.test.ts
+++ b/server/src/config/__tests__/redis.test.ts
@@ -1,0 +1,53 @@
+const mockCreateClient = jest.fn(() => ({
+  on: jest.fn(),
+}))
+
+jest.mock('redis', () => ({
+  createClient: mockCreateClient,
+}))
+
+describe('redisClient', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockCreateClient.mockClear()
+  })
+
+  afterEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('should export REDIS constants', () => {
+    const { REDIS_URL } = require('../redis')
+    expect(REDIS_URL).toBe('redis://test_redis')
+  })
+
+  it('should create a Redis client with the correct URL', () => {
+    const { createRedisClient } = require('../redis')
+
+    createRedisClient('redis://test_redis')
+
+    expect(mockCreateClient).toHaveBeenCalledWith({
+      url: 'redis://test_redis',
+    })
+  })
+
+  it('should not reset Redis client if it is already null', () => {
+    const { resetRedisClient } = require('../redis')
+
+    resetRedisClient()
+
+    expect(mockCreateClient).not.toHaveBeenCalled()
+  })
+
+  it('should return the same client instance', () => {
+    const { getRedisClient, resetRedisClient } = require('../redis')
+
+    resetRedisClient() // 테스트를 위해 리셋
+
+    const client1 = getRedisClient()
+    const client2 = getRedisClient()
+
+    expect(client1).toBe(client2)
+    expect(mockCreateClient).toHaveBeenCalledTimes(1)
+  })
+})

--- a/server/src/config/redis.ts
+++ b/server/src/config/redis.ts
@@ -9,6 +9,12 @@ export function createRedisClient(url: string = REDIS_URL): RedisClientType {
 
 let _redisClient: RedisClientType | null = null
 
+/**
+ * Redis 클라이언트를 가져오는 함수입니다.
+ * 클라이언트가 아직 생성되지 않았다면 새로 생성합니다.
+ *
+ * @returns {RedisClientType} Redis 클라이언트 인스턴스
+ */
 export const getRedisClient = (): RedisClientType => {
   if (!_redisClient) {
     _redisClient = createRedisClient()
@@ -16,10 +22,17 @@ export const getRedisClient = (): RedisClientType => {
   return _redisClient
 }
 
+/**
+ * Redis 클라이언트를 재설정하는 함수입니다.
+ * 기존 클라이언트를 null로 설정하여 다음 호출 시 새 클라이언트를 생성하도록 합니다.
+ */
 export const resetRedisClient = (): void => {
   if (_redisClient) {
     _redisClient = null
   }
 }
 
+/**
+ * 싱글톤 Redis 클라이언트를 가져옵니다.
+ */
 export const redisClient = getRedisClient()

--- a/server/src/config/redis.ts
+++ b/server/src/config/redis.ts
@@ -1,0 +1,25 @@
+import { createClient, RedisClientType } from 'redis'
+import { getEnv } from '../utils/env'
+
+export const REDIS_URL = getEnv('REDIS_URL')
+
+export function createRedisClient(url: string = REDIS_URL): RedisClientType {
+  return createClient({ url })
+}
+
+let _redisClient: RedisClientType | null = null
+
+export const getRedisClient = (): RedisClientType => {
+  if (!_redisClient) {
+    _redisClient = createRedisClient()
+  }
+  return _redisClient
+}
+
+export const resetRedisClient = (): void => {
+  if (_redisClient) {
+    _redisClient = null
+  }
+}
+
+export const redisClient = getRedisClient()

--- a/server/tsconfig.json
+++ b/server/tsconfig.json
@@ -1,3 +1,6 @@
 {
-  "extends": "@tsconfig/node20/tsconfig.json"
+  "extends": "@tsconfig/node20/tsconfig.json",
+  "compilerOptions": {
+    "isolatedModules": true
+  }
 }


### PR DESCRIPTION
# Changelog
- Redis를 사용하기 위한 환경변수를 구성하고, 싱글톤 Redis 클라이언트를 구현하였습니다.
- `.env`파일을 테스트에서도 편하게 사용하기 위해 `.env.test`를 구성하고 `jest.config.ts` 에서 export하도록 하였습니다.

# Testing
<img width="807" height="738" alt="image" src="https://github.com/user-attachments/assets/cdbbc2b6-9c33-4ee8-895b-80a0e29c8cbd" />

# Ops Impact
N/A

# Version Compatibility
N/A