### PR TITLE
[Server] 인증 및 토큰 관련 Auth Service 구현

### DIFF
--- a/server/src/services/__tests__/authService.test.ts
+++ b/server/src/services/__tests__/authService.test.ts
@@ -1,0 +1,123 @@
+import {
+  authService,
+  CodeDoesnotExistError,
+  PHONE_VERIFICATION_EXPIRATION,
+  RefreshTokenNotFoundError,
+} from '../authService'
+import { redisClient } from '../../config/redis'
+import { generateAccessToken, generateRefreshToken } from '../../config/jwt'
+import { sendSMSVerificationCode } from '../coolsmsService'
+import { prismaMock } from '../../../prisma/mock'
+
+jest.mock('../../config/redis')
+jest.mock('../../config/jwt')
+jest.mock('../coolsmsService')
+
+describe('authService', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  describe('sendVerificationCode', () => {
+    it('should generate code, store in redis, and send SMS', async () => {
+      jest.spyOn(Math, 'random').mockReturnValue(0)
+
+      const setExMock = jest.fn().mockResolvedValue(undefined)
+      ;(redisClient.setEx as jest.Mock) = setExMock
+
+      const sendSMSMock = jest.fn()
+      ;(sendSMSVerificationCode as jest.Mock) = sendSMSMock
+
+      const phoneNumber = '01012345678'
+
+      await authService.sendVerificationCode(phoneNumber)
+
+      expect(setExMock).toHaveBeenCalledWith(
+        `phone_verification:${phoneNumber}`,
+        PHONE_VERIFICATION_EXPIRATION,
+        '100000',
+      )
+      expect(sendSMSMock).toHaveBeenCalledWith(phoneNumber, 100000)
+    })
+
+    it('should throw error if redis or sms fails', async () => {
+      ;(redisClient.setEx as jest.Mock).mockRejectedValue(new Error('redis fail'))
+      const phoneNumber = '01012345678'
+      await expect(authService.sendVerificationCode(phoneNumber)).rejects.toThrow('Failed to send verification code')
+    })
+  })
+
+  describe('verifyPhoneCode', () => {
+    it('should return true if code matches', async () => {
+      ;(redisClient.get as jest.Mock).mockResolvedValue('123456')
+      const result = await authService.verifyPhoneCode('01012345678', 123456)
+      expect(result).toBe(true)
+    })
+
+    it('should return false if code does not match', async () => {
+      ;(redisClient.get as jest.Mock).mockResolvedValue('654321')
+      const result = await authService.verifyPhoneCode('01012345678', 123456)
+      expect(result).toBe(false)
+    })
+
+    it('should throw CodeDoesnotExistError if code not found', async () => {
+      ;(redisClient.get as jest.Mock).mockResolvedValue(null)
+      await expect(authService.verifyPhoneCode('01012345678', 123456)).rejects.toThrow(CodeDoesnotExistError)
+    })
+  })
+
+  describe('generateTokens', () => {
+    it('should generate tokens and upsert refreshToken', async () => {
+      ;(generateAccessToken as jest.Mock).mockReturnValue('access-token')
+      ;(generateRefreshToken as jest.Mock).mockReturnValue('refresh-token')
+      prismaMock.refreshToken.upsert.mockResolvedValue({
+        id: 1,
+        user_id: 1,
+        token: 'refresh-token',
+        expires_at: new Date(),
+        created_at: new Date(),
+        revoked_at: null,
+        is_revoked: false,
+      })
+
+      const result = await authService.generateTokens(1)
+
+      expect(generateAccessToken).toHaveBeenCalledWith(1)
+      expect(generateRefreshToken).toHaveBeenCalledWith(1)
+
+      expect(prismaMock.refreshToken.upsert).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { user_id: 1 },
+          update: expect.any(Object),
+          create: expect.any(Object),
+        }),
+      )
+      expect(result).toEqual({
+        accessToken: 'access-token',
+        refreshToken: 'refresh-token',
+      })
+    })
+  })
+
+  describe('getRefreshTokenByUserId', () => {
+    it('should return token if found', async () => {
+      prismaMock.refreshToken.findUnique.mockResolvedValue({
+        id: 1,
+        user_id: 1,
+        token: 'refresh-token',
+        expires_at: new Date(),
+        created_at: new Date(),
+        revoked_at: null,
+        is_revoked: false,
+      })
+
+      const result = await authService.getRefreshTokenByUserId(1)
+      expect(result).toBe('refresh-token')
+    })
+
+    it('should throw RefreshTokenNotFoundError if not found', async () => {
+      prismaMock.refreshToken.findUnique.mockResolvedValue(null)
+      await expect(authService.getRefreshTokenByUserId(1)).rejects.toThrow(RefreshTokenNotFoundError)
+    })
+  })
+})

--- a/server/src/services/authService.ts
+++ b/server/src/services/authService.ts
@@ -1,0 +1,136 @@
+import { prisma } from '../../prisma/prisma'
+import { generateAccessToken, generateRefreshToken } from '../config/jwt'
+import { redisClient } from '../config/redis'
+import { sendSMSVerificationCode } from './coolsmsService'
+
+export const PHONE_VERIFICATION_EXPIRATION = 5 * 60 // 5분(초 단위)
+
+/**
+ * 인증 코드가 존재하지 않거나 만료된 경우 발생하는 에러 클래스입니다.
+ */
+export class CodeDoesnotExistError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'CodeDoesnotExistError'
+  }
+}
+
+/**
+ * 리프레시 토큰이 존재하지 않는 경우 발생하는 에러 클래스입니다.
+ */
+export class RefreshTokenNotFoundError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'RefreshTokenNotFoundError'
+  }
+}
+
+/**
+ * 액세스 토큰과 리프레시 토큰을 담는 인터페이스입니다.
+ * @property accessToken 액세스 토큰 문자열
+ * @property refreshToken 리프레시 토큰 문자열
+ */
+interface Tokens {
+  accessToken: string
+  refreshToken: string
+}
+
+/**
+ * 인증 관련 서비스 객체입니다.
+ * 휴대폰 인증 코드 발송, 인증 코드 검증, JWT 토큰 발급 기능을 제공합니다.
+ */
+export const authService = {
+  /**
+   * 주어진 휴대폰 번호로 6자리 인증 코드를 생성하여 SMS로 전송합니다.
+   * 인증 코드는 Redis에 `PHONE_VERIFICATION_EXPIRATION`기간 동안 저장됩니다.
+   *
+   * @param {string} phoneNumber - 인증 코드를 받을 휴대폰 번호
+   * @returns {Promise<void>} 반환값 없음
+   * @throws 인증 코드 발송에 실패할 경우 에러를 발생시킵니다.
+   */
+  sendVerificationCode: async (phoneNumber: string): Promise<void> => {
+    try {
+      const code = Math.floor(100000 + Math.random() * 900000) // 6자리 랜덤 코드 생성
+
+      await redisClient.setEx(`phone_verification:${phoneNumber}`, PHONE_VERIFICATION_EXPIRATION, code.toString())
+
+      sendSMSVerificationCode(phoneNumber, code)
+    } catch (error) {
+      throw new Error('Failed to send verification code')
+    }
+  },
+
+  /**
+   * 휴대폰 번호와 입력된 인증 코드가 일치하는지 검증합니다.
+   * 인증 코드는 Redis에서 조회하며, 일치하지 않거나 만료된 경우 에러를 발생시킵니다.
+   *
+   * @async
+   * @param {string} phoneNumber - 인증을 시도하는 휴대폰 번호
+   * @param {number} code - 사용자가 입력한 인증 코드
+   * @returns {Promise<boolean>} 인증 성공 여부 (성공 시 true)
+   * @throws 인증 코드가 없거나 일치하지 않을 경우 에러를 발생시킵니다.
+   */
+  verifyPhoneCode: async (phoneNumber: string, code: number): Promise<boolean> => {
+    const storedCode = await redisClient.get(`phone_verification:${phoneNumber}`)
+
+    if (!storedCode) {
+      throw new CodeDoesnotExistError('Verification code does not exist or has expired')
+    }
+
+    return storedCode === code.toString()
+  },
+
+  /**
+   * 주어진 사용자 ID로 액세스 토큰과 리프레시 토큰을 생성합니다.
+   * 리프레시 토큰은 데이터베이스에 저장(또는 갱신)되며, 만료일은 30일 후로 설정됩니다.
+   *
+   * @async
+   * @param {number} userId - 토큰을 생성할 사용자 ID
+   * @returns {Promise<Tokens>} 생성된 액세스 토큰과 리프레시 토큰 객체
+   */
+  generateTokens: async (userId: number): Promise<Tokens> => {
+    const accessToken = generateAccessToken(userId)
+    const refreshToken = generateRefreshToken(userId)
+
+    const expiresAt = new Date()
+    expiresAt.setDate(expiresAt.getDate() + 30)
+
+    await prisma.refreshToken.upsert({
+      where: { user_id: userId },
+      update: {
+        token: refreshToken,
+        expires_at: expiresAt,
+      },
+      create: {
+        user_id: userId,
+        token: refreshToken,
+        expires_at: expiresAt,
+      },
+    })
+
+    return {
+      accessToken,
+      refreshToken,
+    }
+  },
+
+  /**
+   * 주어진 사용자 ID로 저장된 리프레시 토큰을 조회합니다.
+   * 해당 사용자의 리프레시 토큰이 없으면 null을 반환합니다.
+   *
+   * @async
+   * @param {number} userId - 리프레시 토큰을 조회할 사용자 ID
+   * @returns {Promise<string>} 해당 사용자의 리프레시 토큰 문자열
+   */
+  getRefreshTokenByUserId: async (userId: number): Promise<string> => {
+    const tokenRecord = await prisma.refreshToken.findUnique({
+      where: { user_id: userId },
+    })
+
+    if (!tokenRecord) {
+      throw new RefreshTokenNotFoundError('Refresh token not found for the user')
+    }
+
+    return tokenRecord.token
+  },
+}

--- a/server/src/utils/__tests__/nickname.test.ts
+++ b/server/src/utils/__tests__/nickname.test.ts
@@ -1,0 +1,24 @@
+import { generateRandomNickname } from '../nickname'
+import { redisClient } from '../../config/redis'
+
+jest.mock('../../config/redis', () => ({
+  redisClient: {
+    incr: jest.fn(),
+  },
+}))
+
+describe('generateRandomNickname', () => {
+  it('Returns a random nickname', async () => {
+    // Redis의 incr 메서드가 1을 반환하도록 mock
+    ;(redisClient.incr as jest.Mock).mockResolvedValue(1)
+
+    // 랜덤 함수 0을 반환하도록 mock
+    jest.spyOn(Math, 'random').mockReturnValue(0)
+
+    const nickname = await generateRandomNickname()
+
+    // 닉네임 형식: "형용사 동물 #1"
+    expect(nickname).toBe('귀여운 고양이 #1')
+    expect(redisClient.incr).toHaveBeenCalledTimes(1)
+  })
+})

--- a/server/src/utils/nickname.ts
+++ b/server/src/utils/nickname.ts
@@ -1,0 +1,28 @@
+import { redisClient } from '../config/redis'
+
+const adjectives = [
+  '귀여운',
+  '멋진',
+  '용감한',
+  '영리한',
+  '재치있는',
+  '활기찬',
+  '우아한',
+  '신나는',
+  '행복한',
+  '아름다운',
+]
+
+const animals = ['고양이', '강아지', '토끼', '곰', '호랑이', '펭귄', '돌고래', '거북이', '올빼미', '판다']
+
+export const generateRandomNickname = async (): Promise<string> => {
+  const adjectiveIdx = Math.floor(Math.random() * adjectives.length)
+  const animalIdx = Math.floor(Math.random() * animals.length)
+
+  const nickname = `${adjectives[adjectiveIdx]} ${animals[animalIdx]}`
+
+  // Redis에서 닉네임 인덱스를 증가시키고, 해당 닉네임에 번호를 붙여 반환
+  const idx = await redisClient.incr(`nickname_index:${nickname}`)
+
+  return `${nickname} #${idx}`
+}


### PR DESCRIPTION
# Changelog
- 휴대폰 인증, JWT토큰 및 리프레시 토큰을 생성하는 Auth Service를 구현하였습니다.
- 닉네임을 랜덤으로 생성하고 중복되는 닉네임이 있는 경우 Suffix 숫자로 중복을 방지하는 랜덤 닉네임 생성기를 구현하였습니다.

# Testing
<img width="821" height="740" alt="image" src="https://github.com/user-attachments/assets/2eff7224-fc98-4671-8b30-5ff9cc8b1c78" />

# Ops Impact
N/A

# Version Compatibility
N/A