### PR TITLE
[Server] 사용자 데이터를 관리하는 User Service 구현

### DIFF
--- a/server/.env.example
+++ b/server/.env.example
@@ -15,3 +15,9 @@ COOLSMS_FROM_PHONE_NUMBER=your_coolsms_from_phone_number
 
 # Redis Settings
 REDIS_URL=your_redis_url
+
+# JWT Settings
+JWT_SECRET=your_jwt_secret
+JWT_REFRESH_SECRET=your_jwt_refresh_secret
+JWT_EXPIRES_IN=1h
+JWT_REFRESH_EXPIRES_IN=30d

--- a/server/src/services/__tests__/userService.test.ts
+++ b/server/src/services/__tests__/userService.test.ts
@@ -1,0 +1,103 @@
+import { userService } from '../userService'
+import { prismaMock } from '../../../prisma/mock'
+import { User } from '@prisma/client'
+
+describe('userService', () => {
+  const mockUser: User = {
+    id: 1,
+    phone: '01012345678',
+    nickname: '테스터',
+    is_authenticated: true,
+    created_at: new Date(),
+    updated_at: new Date(),
+  }
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  describe('findUserByPhone', () => {
+    it('should return user if found', async () => {
+      ;(prismaMock.user.findUnique as jest.Mock).mockResolvedValue(mockUser)
+      const result = await userService.findUserByPhone('01012345678')
+
+      expect(prismaMock.user.findUnique).toHaveBeenCalledWith({
+        where: { phone: '01012345678' },
+      })
+      expect(result).toEqual(mockUser)
+    })
+
+    it('should return null if user not found', async () => {
+      ;(prismaMock.user.findUnique as jest.Mock).mockResolvedValue(null)
+      const result = await userService.findUserByPhone('01000000000')
+
+      expect(result).toBeNull()
+    })
+  })
+
+  describe('findUserById', () => {
+    it('should return user if found by id', async () => {
+      ;(prismaMock.user.findUnique as jest.Mock).mockResolvedValue(mockUser)
+      const result = await userService.findUserById(1)
+
+      expect(prismaMock.user.findUnique).toHaveBeenCalledWith({
+        where: { id: 1 },
+      })
+      expect(result).toEqual(mockUser)
+    })
+
+    it('should return null if user with id not found', async () => {
+      ;(prismaMock.user.findUnique as jest.Mock).mockResolvedValue(null)
+      const result = await userService.findUserById(999)
+
+      expect(result).toBeNull()
+    })
+  })
+
+  describe('createUser', () => {
+    it('should create and return new user', async () => {
+      const createdUser = { ...mockUser, id: 2 }
+      ;(prismaMock.user.create as jest.Mock).mockResolvedValue(createdUser)
+
+      const result = await userService.createUser('01087654321', '새유저', true)
+
+      expect(prismaMock.user.create).toHaveBeenCalledWith({
+        data: {
+          phone: '01087654321',
+          nickname: '새유저',
+          is_authenticated: true,
+        },
+      })
+      expect(result).toEqual(createdUser)
+    })
+  })
+
+  describe('checkNicknameExists', () => {
+    it('should return true if nickname exists', async () => {
+      ;(prismaMock.user.findUnique as jest.Mock).mockResolvedValue(mockUser)
+      const result = await userService.checkNicknameExists('테스터')
+      expect(result).toBe(true)
+    })
+
+    it('should return false if nickname does not exist', async () => {
+      ;(prismaMock.user.findUnique as jest.Mock).mockResolvedValue(null)
+      const result = await userService.checkNicknameExists('없는닉네임')
+      expect(result).toBe(false)
+    })
+  })
+
+  describe('updateUserNickname', () => {
+    it('should update nickname and return updated user', async () => {
+      const updatedUser = { ...mockUser, nickname: '변경된 닉네임' }
+      ;(prismaMock.user.update as jest.Mock).mockResolvedValue(updatedUser)
+
+      const result = await userService.updateUserNickname(1, '변경된 닉네임')
+
+      expect(prismaMock.user.update).toHaveBeenCalledWith({
+        where: { id: 1 },
+        data: { nickname: '변경된 닉네임' },
+      })
+      expect(result).toEqual(updatedUser)
+    })
+  })
+})

--- a/server/src/services/userService.ts
+++ b/server/src/services/userService.ts
@@ -1,0 +1,86 @@
+import { prisma } from '../../prisma/prisma'
+import { User } from '@prisma/client'
+
+/**
+ * 사용자 관련 데이터베이스 작업을 처리하는 서비스 객체입니다.
+ * 사용자 조회, 생성, 닉네임 중복 확인, 닉네임 변경 기능을 제공합니다.
+ */
+export const userService = {
+  /**
+   * 휴대폰 번호로 사용자를 조회합니다.
+   *
+   * @async
+   * @param {string} phoneNumber - 조회할 사용자의 휴대폰 번호
+   * @returns {Promise<User | null>} 해당 번호의 사용자 객체 또는 null
+   */
+  findUserByPhone: async (phoneNumber: string): Promise<User | null> => {
+    const user = await prisma.user.findUnique({
+      where: { phone: phoneNumber },
+    })
+    return user
+  },
+
+  /**
+   * 사용자 ID로 사용자를 조회합니다.
+   *
+   * @async
+   * @param {number} userId - 조회할 사용자의 ID
+   * @returns {Promise<User | null>} 해당 ID의 사용자 객체 또는 null
+   */
+  findUserById: async (userId: number): Promise<User | null> => {
+    const user = await prisma.user.findUnique({
+      where: { id: userId },
+    })
+    return user
+  },
+
+  /**
+   * 새로운 사용자를 생성합니다.
+   *
+   * @async
+   * @param {string} phoneNumber - 생성할 사용자의 휴대폰 번호
+   * @param {string} nickname - 생성할 사용자의 닉네임
+   * @param {boolean} isAuthenticated - 인증 여부
+   * @returns {Promise<User>} 생성된 사용자 객체
+   */
+  createUser: async (phoneNumber: string, nickname: string, isAuthenticated: boolean): Promise<User> => {
+    const user = await prisma.user.create({
+      data: {
+        phone: phoneNumber,
+        nickname: nickname,
+        is_authenticated: isAuthenticated,
+      },
+    })
+    return user
+  },
+
+  /**
+   * 닉네임이 이미 존재하는지 확인합니다.
+   *
+   * @async
+   * @param {string} nickname - 중복 확인할 닉네임
+   * @returns {Promise<boolean>} 닉네임 존재 여부 (true: 존재함, false: 존재하지 않음)
+   */
+  checkNicknameExists: async (nickname: string): Promise<boolean> => {
+    const user = await prisma.user.findUnique({
+      where: { nickname },
+    })
+    return !!user
+  },
+
+  /**
+   * 사용자의 닉네임을 변경합니다.
+   *
+   * @async
+   * @param {number} userId - 닉네임을 변경할 사용자의 ID
+   * @param {string} nickname - 변경할 닉네임
+   * @returns {Promise<User>} 닉네임이 변경된 사용자 객체
+   */
+  updateUserNickname: async (userId: number, nickname: string): Promise<User> => {
+    const user = await prisma.user.update({
+      where: { id: userId },
+      data: { nickname },
+    })
+    return user
+  },
+}


### PR DESCRIPTION
# Changelog
- 사용자 정보를 조회하거나 변경하는 역할의 User Service를 구현하였습니다.
- JWT토큰과 관련된 필요한 환경변수를 `.env.example`에 추가하였습니다.

# Testing
<img width="811" height="739" alt="image" src="https://github.com/user-attachments/assets/16f1bb0d-7d9d-405c-82d4-465c38bfa78b" />

# Ops Impact
N/A

# Version Compatibility
N/A