### PR TITLE
[Server] Auth Controller 구현

### DIFF
--- a/server/src/controllers/__tests__/authController.test.ts
+++ b/server/src/controllers/__tests__/authController.test.ts
@@ -1,0 +1,230 @@
+import { requestPhoneAuth, verifyPhoneAuth, refreshAccessToken } from '../authController'
+import { sendError, sendSuccess } from '../../utils/response'
+import { authService, CodeDoesnotExistError, RefreshTokenNotFoundError } from '../../services/authService'
+import { userService } from '../../services/userService'
+import { generateRandomNickname } from '../../utils/nickname'
+import { verifyRefreshToken } from '../../config/jwt'
+
+jest.mock('../../utils/response')
+jest.mock('../../services/authService')
+jest.mock('../../services/userService')
+jest.mock('../../utils/nickname')
+jest.mock('../../config/jwt')
+
+const mockReq = (body: any = {}) => ({ body }) as any
+const mockRes = () => {
+  const res: any = {}
+  res.status = jest.fn(() => res)
+  res.send = jest.fn(() => res)
+  res.json = jest.fn(() => res)
+  return res
+}
+
+beforeEach(() => {
+  jest.clearAllMocks()
+})
+
+describe('requestPhoneAuth', () => {
+  it('should return 400 if phoneNumber is missing', async () => {
+    const req = mockReq({})
+    const res = mockRes()
+
+    await requestPhoneAuth(req, res)
+
+    expect(sendError).toHaveBeenCalledWith(res, 'Phone number is required', 400)
+  })
+
+  it('should call sendVerificationCode and sendSuccess if phoneNumber exists', async () => {
+    ;(authService.sendVerificationCode as jest.Mock).mockReturnValue(undefined)
+    const req = mockReq({ phoneNumber: '01012345678' })
+    const res = mockRes()
+
+    await requestPhoneAuth(req, res)
+
+    expect(authService.sendVerificationCode).toHaveBeenCalledWith('01012345678')
+    expect(sendSuccess).toHaveBeenCalledWith(res, 'Verification code sent successfully')
+  })
+
+  it('should catch errors and send 500', async () => {
+    ;(authService.sendVerificationCode as jest.Mock).mockImplementation(() => {
+      throw new Error()
+    })
+    const req = mockReq({ phoneNumber: '01012345678' })
+    const res = mockRes()
+
+    await requestPhoneAuth(req, res)
+
+    expect(sendError).toHaveBeenCalledWith(res, 'Internal server error', 500)
+  })
+})
+
+describe('verifyPhoneAuth', () => {
+  it('should return 400 if phoneNumber or code is missing', async () => {
+    const res = mockRes()
+
+    await verifyPhoneAuth(mockReq({ code: '123456' }), res)
+    expect(sendError).toHaveBeenCalledWith(res, 'Phone number and code are required', 400)
+
+    await verifyPhoneAuth(mockReq({ phoneNumber: '01012345678' }), res)
+    expect(sendError).toHaveBeenCalledWith(res, 'Phone number and code are required', 400)
+  })
+
+  it('should return 400 if verification code is invalid', async () => {
+    ;(authService.verifyPhoneCode as jest.Mock).mockResolvedValue(false)
+    const req = mockReq({ phoneNumber: '010', code: '123' })
+    const res = mockRes()
+
+    await verifyPhoneAuth(req, res)
+
+    expect(sendError).toHaveBeenCalledWith(res, 'Invalid verification code', 400)
+  })
+
+  it('should return user data and tokens if user exists', async () => {
+    ;(authService.verifyPhoneCode as jest.Mock).mockResolvedValue(true)
+    ;(userService.findUserByPhone as jest.Mock).mockResolvedValue({ id: 1, phone: '010', nickname: '닉네임' })
+    ;(authService.generateTokens as jest.Mock).mockResolvedValue({ accessToken: 'A', refreshToken: 'R' })
+
+    const req = mockReq({ phoneNumber: '010', code: '123' })
+    const res = mockRes()
+
+    await verifyPhoneAuth(req, res)
+
+    expect(sendSuccess).toHaveBeenCalledWith(res, {
+      user: { id: 1, phone: '010', nickname: '닉네임' },
+      tokens: { accessToken: 'A', refreshToken: 'R' },
+    })
+  })
+
+  it('should create new user if not exists and return user data and tokens', async () => {
+    ;(authService.verifyPhoneCode as jest.Mock).mockResolvedValue(true)
+    ;(userService.findUserByPhone as jest.Mock).mockResolvedValue(null)
+    ;(generateRandomNickname as jest.Mock).mockResolvedValue('랜덤닉네임')
+    ;(userService.createUser as jest.Mock).mockResolvedValue({ id: 1, phone: '010', nickname: '랜덤닉네임' })
+    ;(authService.generateTokens as jest.Mock).mockResolvedValue({ accessToken: 'A', refreshToken: 'R' })
+
+    const req = mockReq({ phoneNumber: '010', code: '123' })
+    const res = mockRes()
+
+    await verifyPhoneAuth(req, res)
+
+    expect(userService.createUser).toHaveBeenCalledWith('010', '랜덤닉네임', true)
+    expect(sendSuccess).toHaveBeenCalledWith(res, {
+      user: { id: 1, phone: '010', nickname: '랜덤닉네임' },
+      tokens: { accessToken: 'A', refreshToken: 'R' },
+    })
+  })
+
+  it('should handle CodeDoesnotExistError', async () => {
+    ;(authService.verifyPhoneCode as jest.Mock).mockImplementation(() => {
+      throw new CodeDoesnotExistError('Verification code does not exist or has expired')
+    })
+    const req = mockReq({ phoneNumber: '010', code: '123' })
+    const res = mockRes()
+
+    await verifyPhoneAuth(req, res)
+
+    expect(sendError).toHaveBeenCalledWith(res, 'Verification code does not exist or has expired', 400)
+  })
+
+  it('should return Internal server error on unexpected error', async () => {
+    ;(authService.verifyPhoneCode as jest.Mock).mockImplementation(() => {
+      throw new Error('Unexpected error')
+    })
+    const req = mockReq({ phoneNumber: '010', code: '123' })
+    const res = mockRes()
+
+    await verifyPhoneAuth(req, res)
+
+    expect(sendError).toHaveBeenCalledWith(res, 'Internal server error', 500)
+  })
+})
+
+describe('refreshAccessToken', () => {
+  it('should return 400 if refreshToken is missing', async () => {
+    const req = mockReq({})
+    const res = mockRes()
+
+    await refreshAccessToken(req, res)
+
+    expect(sendError).toHaveBeenCalledWith(res, 'Refresh token is required', 400)
+  })
+
+  it('should return 401 if dbToken not found', async () => {
+    ;(verifyRefreshToken as jest.Mock).mockReturnValue({ userId: 1 })
+    ;(authService.getRefreshTokenByUserId as jest.Mock).mockResolvedValue(undefined)
+
+    const req = mockReq({ refreshToken: 'RT' })
+    const res = mockRes()
+
+    await refreshAccessToken(req, res)
+
+    expect(sendError).toHaveBeenCalledWith(res, 'Refresh token not found', 401)
+  })
+
+  it('should return 401 if tokens are not matched', async () => {
+    ;(verifyRefreshToken as jest.Mock).mockReturnValue({ userId: 1 })
+    ;(authService.getRefreshTokenByUserId as jest.Mock).mockResolvedValue('DB_RT_NOT_MATCH')
+
+    const req = mockReq({ refreshToken: 'RT' })
+    const res = mockRes()
+
+    await refreshAccessToken(req, res)
+
+    expect(sendError).toHaveBeenCalledWith(res, 'Invalid refresh token', 401)
+  })
+
+  it('should return 404 if user is not found', async () => {
+    ;(verifyRefreshToken as jest.Mock).mockReturnValue({ userId: 1 })
+    ;(authService.getRefreshTokenByUserId as jest.Mock).mockResolvedValue('RT')
+    ;(userService.findUserById as jest.Mock).mockResolvedValue(undefined)
+
+    const req = mockReq({ refreshToken: 'RT' })
+    const res = mockRes()
+
+    await refreshAccessToken(req, res)
+
+    expect(sendError).toHaveBeenCalledWith(res, 'User not found', 404)
+  })
+
+  it('should generate and return new tokens if valid', async () => {
+    ;(verifyRefreshToken as jest.Mock).mockReturnValue({ userId: 1 })
+    ;(authService.getRefreshTokenByUserId as jest.Mock).mockResolvedValue('RT')
+    ;(userService.findUserById as jest.Mock).mockResolvedValue({ id: 1 })
+    ;(authService.generateTokens as jest.Mock).mockResolvedValue({ accessToken: 'A', refreshToken: 'R' })
+
+    const req = mockReq({ refreshToken: 'RT' })
+    const res = mockRes()
+
+    await refreshAccessToken(req, res)
+
+    expect(sendSuccess).toHaveBeenCalledWith(res, { accessToken: 'A', refreshToken: 'R' })
+  })
+
+  it('should handle RefreshTokenNotFoundError', async () => {
+    ;(verifyRefreshToken as jest.Mock).mockReturnValue({ userId: 1 })
+    ;(authService.getRefreshTokenByUserId as jest.Mock).mockImplementation(() => {
+      throw new RefreshTokenNotFoundError('Refresh token not found for the user')
+    })
+
+    const req = mockReq({ refreshToken: 'RT' })
+    const res = mockRes()
+
+    await refreshAccessToken(req, res)
+
+    expect(sendError).toHaveBeenCalledWith(res, 'Refresh token not found for the user', 401)
+  })
+
+  it('should handle unexpected errors', async () => {
+    ;(verifyRefreshToken as jest.Mock).mockReturnValue({ userId: 1 })
+    ;(authService.getRefreshTokenByUserId as jest.Mock).mockImplementation(() => {
+      throw new Error('Unexpected error')
+    })
+
+    const req = mockReq({ refreshToken: 'RT' })
+    const res = mockRes()
+
+    await refreshAccessToken(req, res)
+
+    expect(sendError).toHaveBeenCalledWith(res, 'Invalid refresh token', 401)
+  })
+})

--- a/server/src/controllers/authController.ts
+++ b/server/src/controllers/authController.ts
@@ -1,0 +1,138 @@
+import { Request, Response } from 'express'
+import { sendError, sendSuccess } from '../utils/response'
+import { authService, CodeDoesnotExistError, RefreshTokenNotFoundError } from '../services/authService'
+import { userService } from '../services/userService'
+import { generateRandomNickname } from '../utils/nickname'
+import { verifyRefreshToken } from '../config/jwt'
+
+/**
+ * 휴대폰 번호로 인증을 요청하는 컨트롤러입니다.
+ * 사용자가 휴대폰 번호를 입력하면, 해당 번호로 인증 코드를 전송합니다.
+ *
+ * @param {Request} req - Express 요청 객체. body에 phoneNumber가 포함되어야 합니다.
+ * @param {Response} res - Express 응답 객체.
+ *
+ * @example
+ * // 요청 예시
+ * POST /api/auth/phone/request
+ * {
+ *   "phoneNumber": "01012345678"
+ * }
+ */
+export const requestPhoneAuth = async (req: Request, res: Response) => {
+  const { phoneNumber } = req.body
+
+  if (!phoneNumber) {
+    return sendError(res, 'Phone number is required', 400)
+  }
+
+  try {
+    authService.sendVerificationCode(phoneNumber)
+    return sendSuccess(res, 'Verification code sent successfully')
+  } catch (error) {
+    return sendError(res, 'Internal server error', 500)
+  }
+}
+
+/**
+ * 휴대폰 번호로 인증 코드를 검증하는 컨트롤러입니다.
+ * 사용자가 입력한 인증 코드가 올바른지 확인하고, 사용자 정보와 JWT 토큰을 반환합니다.
+ * 사용자가 해당 번호로 인증을 받은 적이 없다면, 새로운 사용자를 생성하여 반환합니다.
+ *
+ * @param {Request} req - Express 요청 객체. body에 phoneNumber와 code가 포함되어야 합니다.
+ * @param {Response} res - Express 응답 객체.
+ *
+ * @example
+ * // 요청 예시
+ * POST /api/auth/phone/verify
+ *
+ * {
+ *   "phoneNumber": "01012345678",
+ *   "code": "123456"
+ * }
+ */
+export const verifyPhoneAuth = async (req: Request, res: Response) => {
+  const { phoneNumber, code } = req.body
+
+  if (!phoneNumber || !code) {
+    return sendError(res, 'Phone number and code are required', 400)
+  }
+
+  try {
+    const isValidCode = await authService.verifyPhoneCode(phoneNumber, code)
+    if (!isValidCode) {
+      return sendError(res, 'Invalid verification code', 400)
+    }
+
+    let user = await userService.findUserByPhone(phoneNumber)
+    if (!user) {
+      const nickname = await generateRandomNickname()
+      user = await userService.createUser(phoneNumber, nickname, true)
+    }
+
+    const tokens = await authService.generateTokens(user.id)
+
+    const userData = {
+      user: {
+        id: user.id,
+        phone: user.phone,
+        nickname: user.nickname,
+      },
+      tokens,
+    }
+
+    return sendSuccess(res, userData)
+  } catch (error) {
+    if (error instanceof CodeDoesnotExistError) {
+      return sendError(res, 'Verification code does not exist or has expired', 400)
+    }
+    return sendError(res, 'Internal server error', 500)
+  }
+}
+
+/**
+ * 액세스 토큰을 갱신하는 컨트롤러입니다.
+ * 사용자가 유효한 리프레시 토큰을 제공하면, 새로운 액세스 토큰을 발급합니다.
+ * 리프레시 토큰이 유효하지 않거나 만료된 경우, 에러를 반환합니다.
+ *
+ * @param {Request} req - Express 요청 객체. body에 refreshToken이 포함되어야 합니다.
+ * @param {Response} res - Express 응답 객체.
+ * @example
+ * // 요청 예시
+ * POST /api/auth/refresh
+ * {
+ *  "refreshToken": "your_refresh_token_here"
+ *  }
+ */
+export const refreshAccessToken = async (req: Request, res: Response) => {
+  const { refreshToken } = req.body
+  if (!refreshToken) {
+    return sendError(res, 'Refresh token is required', 400)
+  }
+
+  try {
+    const decoded = verifyRefreshToken(refreshToken)
+    const dbToken = await authService.getRefreshTokenByUserId(decoded.userId)
+    if (!dbToken) {
+      return sendError(res, 'Refresh token not found', 401)
+    }
+
+    if (dbToken !== refreshToken) {
+      return sendError(res, 'Invalid refresh token', 401)
+    }
+
+    const user = await userService.findUserById(decoded.userId)
+    if (!user) {
+      return sendError(res, 'User not found', 404)
+    }
+
+    const tokens = await authService.generateTokens(user.id)
+
+    return sendSuccess(res, tokens)
+  } catch (error) {
+    if (error instanceof RefreshTokenNotFoundError) {
+      return sendError(res, 'Refresh token not found for the user', 401)
+    }
+    return sendError(res, 'Invalid refresh token', 401)
+  }
+}


### PR DESCRIPTION
# Changelog
- 사용자의 인증을 담당하는 Auth Controller를 구현하였습니다.
  - `requestPhoneAuth`: 요청의 휴대폰 번호로 인증번호 발송
  - `verifyPhoneAuth`: 요청의 인증번호를 검증하고 JWT 발급
  - `refreshAccessToken`: 액세스 토큰을 갱신

# Testing
<img width="334" height="387" alt="image" src="https://github.com/user-attachments/assets/f9fc37fc-9e05-4f64-a9f8-5ee04d1e46ad" />

# Ops Impact
N/A

# Version Compatibility
N/A