### PR TITLE
[Server] Response, Error 개선 및 정형화

### DIFF
--- a/server/src/controllers/__tests__/userController.test.ts
+++ b/server/src/controllers/__tests__/userController.test.ts
@@ -1,5 +1,5 @@
 import { updateNickname } from '../userController'
-import { sendError, sendSuccess } from '../../utils/response'
+import { errors, success } from '../../utils/response'
 import { userService } from '../../services/userService'
 import { AuthenticatedRequest } from '../../middlewares/authenticateJWT'
 import { Response } from 'express'
@@ -29,7 +29,7 @@ describe('updateNickname', () => {
 
     await updateNickname(req, res)
 
-    expect(sendError).toHaveBeenCalledWith(res, 'User ID is required', 401)
+    expect(errors.unauthorized).toHaveBeenCalledWith(res, 'User ID is required')
   })
 
   it('should return 400 if nickname is missing', async () => {
@@ -41,8 +41,7 @@ describe('updateNickname', () => {
 
     await updateNickname(req, res)
 
-    expect(res.status).toHaveBeenCalledWith(400)
-    expect(res.json).toHaveBeenCalledWith({ error: 'Nickname is required' })
+    expect(errors.badRequest).toHaveBeenCalledWith(res, 'Nickname is required')
   })
 
   it('should return 400 if nickname already exists', async () => {
@@ -57,7 +56,7 @@ describe('updateNickname', () => {
     await updateNickname(req, res)
 
     expect(userService.checkNicknameExists).toHaveBeenCalledWith('existingNick')
-    expect(sendError).toHaveBeenCalledWith(res, 'Nickname already exists', 400)
+    expect(errors.conflict).toHaveBeenCalledWith(res, 'Nickname already exists')
   })
 
   it('should update nickname and return updated user', async () => {
@@ -84,7 +83,9 @@ describe('updateNickname', () => {
 
     expect(userService.checkNicknameExists).toHaveBeenCalledWith('newNick')
     expect(userService.updateUserNickname).toHaveBeenCalledWith(1, 'newNick')
-    expect(sendSuccess).toHaveBeenCalledWith(res, updatedUser)
+    expect(success).toHaveBeenCalledWith(res, updatedUser, {
+      message: 'Nickname updated successfully',
+    })
   })
 
   it('should return 500 on unexpected error', async () => {
@@ -100,6 +101,6 @@ describe('updateNickname', () => {
 
     await updateNickname(req, res)
 
-    expect(sendError).toHaveBeenCalledWith(res, 'Internal server error', 500)
+    expect(errors.internal).toHaveBeenCalledWith(res)
   })
 })

--- a/server/src/controllers/articleController.ts
+++ b/server/src/controllers/articleController.ts
@@ -1,6 +1,6 @@
 import { Request, Response } from 'express'
 import { prisma } from '../../prisma/prisma'
-import { sendError, sendSuccess } from '../utils/response'
+import { errors, success, successWithOffset } from '../utils/response'
 
 /**
  * 기사 목록을 페이지네이션과 함께 조회합니다.
@@ -21,13 +21,18 @@ export const getArticles = async (req: Request, res: Response) => {
     const totalCount = await prisma.processedArticle.count()
 
     if (articles.length === 0) {
-      return sendError(res, 'No articles found', 404)
+      return errors.notFound(res, 'No articles found')
     }
 
-    return sendSuccess(res, articles, { page, limit, total: totalCount })
+    return successWithOffset(res, articles, {
+      page,
+      limit,
+      total: totalCount,
+      message: 'Articles retrieved successfully',
+    })
   } catch (error) {
     console.error(error)
-    return sendError(res, 'Internal server error', 500)
+    return errors.internal(res)
   }
 }
 
@@ -43,12 +48,14 @@ export const getArticleById = async (req: Request, res: Response) => {
     })
 
     if (!article) {
-      return sendError(res, 'Article not found', 404)
+      return errors.notFound(res)
     }
 
-    sendSuccess(res, article)
+    return success(res, article, {
+      message: 'Article retrieved successfully',
+    })
   } catch (error) {
     console.error(error)
-    return sendError(res, 'Internal server error', 500)
+    return errors.internal(res)
   }
 }

--- a/server/src/controllers/userController.ts
+++ b/server/src/controllers/userController.ts
@@ -1,5 +1,5 @@
 import { Response } from 'express'
-import { sendError, sendSuccess } from '../utils/response'
+import { errors, success } from '../utils/response'
 import { AuthenticatedRequest } from '../middlewares/authenticateJWT'
 import { userService } from '../services/userService'
 
@@ -19,23 +19,25 @@ import { userService } from '../services/userService'
 export const updateNickname = async (req: AuthenticatedRequest, res: Response): Promise<Response> => {
   const userId = req.userId
   if (!userId) {
-    return sendError(res, 'User ID is required', 401)
+    return errors.unauthorized(res, 'User ID is required')
   }
 
   const { nickname } = req.body
   if (!nickname) {
-    return res.status(400).json({ error: 'Nickname is required' })
+    return errors.badRequest(res, 'Nickname is required')
   }
 
   try {
     const isDuplicated = await userService.checkNicknameExists(nickname)
     if (isDuplicated) {
-      return sendError(res, 'Nickname already exists', 400)
+      return errors.conflict(res, 'Nickname already exists')
     }
 
     const updatedUser = await userService.updateUserNickname(userId, nickname)
-    return sendSuccess(res, updatedUser)
+    return success(res, updatedUser, {
+      message: 'Nickname updated successfully',
+    })
   } catch (error) {
-    return sendError(res, 'Internal server error', 500)
+    return errors.internal(res)
   }
 }

--- a/server/src/middlewares/__tests__/authenticateJWT.test.ts
+++ b/server/src/middlewares/__tests__/authenticateJWT.test.ts
@@ -1,5 +1,5 @@
 import { authenticateJWT, AuthenticatedRequest } from '../authenticateJWT'
-import { sendError } from '../../utils/response'
+import { errors } from '../../utils/response'
 import jwt from 'jsonwebtoken'
 
 jest.mock('../../utils/response')
@@ -23,11 +23,9 @@ describe('authenticateJWT middleware', () => {
     const req = { headers: {} } as AuthenticatedRequest
     const res = mockRes()
 
-    ;(sendError as jest.Mock).mockReturnValue(res)
-
     authenticateJWT(req, res, mockNext)
 
-    expect(sendError).toHaveBeenCalledWith(res, 'Access token is required', 401)
+    expect(errors.unauthorized).toHaveBeenCalledWith(res, 'Access token is required')
     expect(mockNext).not.toHaveBeenCalled()
   })
 
@@ -37,11 +35,9 @@ describe('authenticateJWT middleware', () => {
     } as AuthenticatedRequest
     const res = mockRes()
 
-    ;(sendError as jest.Mock).mockReturnValue(res)
-
     authenticateJWT(req, res, mockNext)
 
-    expect(sendError).toHaveBeenCalledWith(res, 'Access token is required', 401)
+    expect(errors.unauthorized).toHaveBeenCalledWith(res, 'Access token is required')
     expect(mockNext).not.toHaveBeenCalled()
   })
 
@@ -77,7 +73,7 @@ describe('authenticateJWT middleware', () => {
 
     authenticateJWT(req, res, mockNext)
 
-    expect(sendError).toHaveBeenCalledWith(res, 'Invalid or expired access token', 401)
+    expect(errors.unauthorized).toHaveBeenCalledWith(res, 'Invalid or expired access token')
     expect(mockNext).not.toHaveBeenCalled()
   })
 })

--- a/server/src/middlewares/authenticateJWT.ts
+++ b/server/src/middlewares/authenticateJWT.ts
@@ -1,6 +1,6 @@
 import jwt from 'jsonwebtoken'
 import { JWT_SECRET } from '../config/jwt'
-import { sendError } from '../utils/response'
+import { errors } from '../utils/response'
 import { Request, Response, NextFunction } from 'express'
 
 /**
@@ -50,7 +50,7 @@ export const authenticateJWT = (req: AuthenticatedRequest, res: Response, next: 
   const token = req.headers.authorization?.split(' ')[1]
 
   if (!token) {
-    return sendError(res, 'Access token is required', 401)
+    return errors.unauthorized(res, 'Access token is required')
   }
 
   try {
@@ -58,6 +58,6 @@ export const authenticateJWT = (req: AuthenticatedRequest, res: Response, next: 
     req.userId = decodedJwtPayload.userId
     next()
   } catch (error) {
-    return sendError(res, 'Invalid or expired access token', 401)
+    return errors.unauthorized(res, 'Invalid or expired access token')
   }
 }

--- a/server/src/utils/__tests__/response.test.ts
+++ b/server/src/utils/__tests__/response.test.ts
@@ -1,72 +1,279 @@
-import { sendSuccess, sendError } from '../response'
-import { createResponse } from 'node-mocks-http'
+import { success, successWithOffset, successWithCursor, error, errors } from '../response'
 
-describe('sendSuccess', () => {
-  it('should return 200 and correct response without pagination', () => {
-    const res = createResponse()
-    const data = { foo: 'bar' }
+const mockRes = () => {
+  const res: any = {}
+  res.status = jest.fn(() => res)
+  res.send = jest.fn(() => res)
+  res.json = jest.fn(() => res)
+  return res
+}
+const getJson = (res: any) => res.json.mock.calls[0][0]
+const getStatus = (res: any) => (res.status.mock.calls.length > 0 ? res.status.mock.calls[0][0] : 200)
 
-    sendSuccess(res, data)
+it('success: only data', () => {
+  const res = mockRes()
+  const data = { id: 1 }
+  success(res, data)
+  expect(getJson(res)).toEqual({ success: true, data })
+})
 
-    expect(res.statusCode).toBe(200)
-    const json = res._getJSONData()
-    expect(json).toEqual({
-      success: true,
-      data,
-      pagination: undefined,
-    })
-  })
+it('success: with message', () => {
+  const res = mockRes()
+  const data = { id: 2 }
+  const message = 'Good!'
+  success(res, data, { message })
+  expect(getJson(res)).toEqual({ success: true, data, message })
+})
 
-  it('should return 200 and correct response with pagination', () => {
-    const res = createResponse()
-    const data = [{ id: 1 }, { id: 2 }]
-    const pagination = { page: 2, limit: 2, total: 10 }
+it('success: with pagination', () => {
+  const res = mockRes()
+  const data = [1, 2, 3]
+  const pagination = {
+    type: 'offset',
+    page: 1,
+    limit: 10,
+    total: 20,
+    totalPages: 2,
+    hasNext: true,
+    hasPrev: false,
+  } as const
+  success(res, data, { pagination })
+  expect(getJson(res)).toEqual({ success: true, data, pagination })
+})
 
-    sendSuccess(res, data, pagination)
+it('success: with message and pagination', () => {
+  const res = mockRes()
+  const data = [1]
+  const pagination = {
+    type: 'cursor',
+    hasNext: false,
+    hasPrev: true,
+    nextCursor: 'abc',
+    prevCursor: 'xyz',
+  } as const
+  const message = 'msg'
+  success(res, data, { message, pagination })
+  expect(getJson(res)).toEqual({ success: true, data, message, pagination })
+})
 
-    expect(res.statusCode).toBe(200)
-    const json = res._getJSONData()
-    expect(json).toEqual({
-      success: true,
-      data,
-      pagination: {
-        page: 2,
-        limit: 2,
-        total: 10,
-        totalPages: 5,
-        hasNextPage: true,
-        hasPreviousPage: true,
-      },
-    })
+it('successWithOffset: first page (has next, no prev)', () => {
+  const res = mockRes()
+  const data = ['a', 'b']
+  const options = { page: 1, limit: 2, total: 5, message: 'fetch' }
+  successWithOffset(res, data, options)
+  expect(getJson(res)).toEqual({
+    success: true,
+    data,
+    message: options.message,
+    pagination: {
+      type: 'offset',
+      page: 1,
+      limit: 2,
+      total: 5,
+      totalPages: 3,
+      hasNext: true,
+      hasPrev: false,
+    },
   })
 })
 
-describe('sendError', () => {
-  it('should return 400 and error message', () => {
-    const res = createResponse()
-    const message = '잘못된 요청입니다.'
-
-    sendError(res, message, 400)
-
-    expect(res.statusCode).toBe(400)
-    const json = res._getJSONData()
-    expect(json).toEqual({
-      success: false,
-      data: message,
-    })
+it('successWithOffset: last page, hasPrev true, hasNext false', () => {
+  const res = mockRes()
+  const data = 'bar'
+  const options = { page: 3, limit: 2, total: 6 }
+  successWithOffset(res, data, options)
+  expect(getJson(res)).toEqual({
+    success: true,
+    data,
+    message: undefined,
+    pagination: {
+      type: 'offset',
+      page: 3,
+      limit: 2,
+      total: 6,
+      totalPages: 3,
+      hasNext: false,
+      hasPrev: true,
+    },
   })
+})
 
-  it('should return default status code 200 if not provided', () => {
-    const res = createResponse()
-    const message = '에러 발생'
-
-    sendError(res, message)
-
-    expect(res.statusCode).toBe(200)
-    const json = res._getJSONData()
-    expect(json).toEqual({
-      success: false,
-      data: message,
-    })
+it('successWithOffset: zero total', () => {
+  const res = mockRes()
+  const data = 'baz'
+  const options = { page: 1, limit: 10, total: 0 }
+  successWithOffset(res, data, options)
+  expect(getJson(res)).toEqual({
+    success: true,
+    data,
+    message: undefined,
+    pagination: {
+      type: 'offset',
+      page: 1,
+      limit: 10,
+      total: 0,
+      totalPages: 0,
+      hasNext: false,
+      hasPrev: false,
+    },
   })
+})
+
+it('successWithCursor: all options', () => {
+  const res = mockRes()
+  const data = [1, 2]
+  const options = {
+    hasNext: true,
+    hasPrev: false,
+    nextCursor: 'abc123',
+    prevCursor: undefined,
+    message: 'done',
+  }
+  successWithCursor(res, data, options)
+  expect(getJson(res)).toEqual({
+    success: true,
+    data,
+    message: options.message,
+    pagination: {
+      type: 'cursor',
+      hasNext: true,
+      hasPrev: false,
+      nextCursor: 'abc123',
+      prevCursor: undefined,
+    },
+  })
+})
+
+it('successWithCursor: missing optional options', () => {
+  const res = mockRes()
+  const data = [42]
+  const options = { hasNext: false }
+  successWithCursor(res, data, options)
+  expect(getJson(res)).toEqual({
+    success: true,
+    data,
+    message: undefined,
+    pagination: {
+      type: 'cursor',
+      hasNext: false,
+      hasPrev: undefined,
+      nextCursor: undefined,
+      prevCursor: undefined,
+    },
+  })
+})
+
+it('error: default status', () => {
+  const res = mockRes()
+  error(res, 'fail!')
+  expect(getStatus(res)).toBe(400)
+  expect(getJson(res)).toEqual({
+    success: false,
+    message: 'fail!',
+  })
+})
+
+it('error: custom status', () => {
+  const res = mockRes()
+  error(res, 'unauth', 401)
+  expect(getStatus(res)).toBe(401)
+  expect(getJson(res)).toEqual({
+    success: false,
+    message: 'unauth',
+  })
+})
+
+it('error: with details', () => {
+  const res = mockRes()
+  error(res, 'something', 422, { details: { foo: 'bar' } })
+  expect(getStatus(res)).toBe(422)
+  expect(getJson(res)).toEqual({
+    success: false,
+    message: 'something',
+    details: { foo: 'bar' },
+  })
+})
+
+it('errors.badRequest: default', () => {
+  let res = mockRes()
+  errors.badRequest(res)
+  expect(getStatus(res)).toBe(400)
+  expect(getJson(res)).toEqual({ success: false, message: 'Bad Request' })
+
+  res = mockRes()
+  errors.badRequest(res, 'Invalid input')
+  expect(getStatus(res)).toBe(400)
+  expect(getJson(res)).toEqual({ success: false, message: 'Invalid input' })
+})
+
+it('errors.unauthorized', () => {
+  let res = mockRes()
+  errors.unauthorized(res)
+  expect(getStatus(res)).toBe(401)
+  expect(getJson(res)).toEqual({ success: false, message: 'Unauthorized' })
+
+  res = mockRes()
+  errors.unauthorized(res, 'No token provided')
+  expect(getStatus(res)).toBe(401)
+  expect(getJson(res)).toEqual({ success: false, message: 'No token provided' })
+})
+
+it('errors.forbidden with custom message', () => {
+  let res = mockRes()
+  errors.forbidden(res)
+  expect(getStatus(res)).toBe(403)
+  expect(getJson(res)).toEqual({ success: false, message: 'Forbidden' })
+
+  res = mockRes()
+  errors.forbidden(res, 'no access')
+  expect(getStatus(res)).toBe(403)
+  expect(getJson(res)).toEqual({ success: false, message: 'no access' })
+})
+
+it('errors.forbidden', () => {
+  let res = mockRes()
+  errors.forbidden(res)
+  expect(getStatus(res)).toBe(403)
+  expect(getJson(res)).toEqual({ success: false, message: 'Forbidden' })
+
+  res = mockRes()
+  errors.forbidden(res, 'no access')
+  expect(getStatus(res)).toBe(403)
+  expect(getJson(res)).toEqual({ success: false, message: 'no access' })
+})
+
+it('errors.notFound', () => {
+  let res = mockRes()
+  errors.notFound(res)
+  expect(getStatus(res)).toBe(404)
+  expect(getJson(res)).toEqual({ success: false, message: 'Not Found' })
+
+  res = mockRes()
+  errors.notFound(res, 'item not found')
+  expect(getStatus(res)).toBe(404)
+  expect(getJson(res)).toEqual({ success: false, message: 'item not found' })
+})
+
+it('errors.conflict', () => {
+  let res = mockRes()
+  errors.conflict(res)
+  expect(getStatus(res)).toBe(409)
+  expect(getJson(res)).toEqual({ success: false, message: 'Conflict' })
+
+  res = mockRes()
+  errors.conflict(res, 'duplicated')
+  expect(getStatus(res)).toBe(409)
+  expect(getJson(res)).toEqual({ success: false, message: 'duplicated' })
+})
+
+it('errors.internal', () => {
+  let res = mockRes()
+  errors.internal(res)
+  expect(getStatus(res)).toBe(500)
+  expect(getJson(res)).toEqual({ success: false, message: 'Internal Server Error' })
+
+  res = mockRes()
+  errors.internal(res, 'unexpected error')
+  expect(getStatus(res)).toBe(500)
+  expect(getJson(res)).toEqual({ success: false, message: 'unexpected error' })
 })

--- a/server/src/utils/response.ts
+++ b/server/src/utils/response.ts
@@ -1,83 +1,197 @@
 import { Response } from 'express'
 
 /**
- * 페이지네이션 정보를 담는 인터페이스입니다.
- * @property page 현재 페이지 번호
- * @property limit 한 페이지당 데이터 개수
- * @property total 전체 데이터 개수
- * @property totalPages 전체 페이지 수
- * @property hasNextPage 다음 페이지 존재 여부
- * @property hasPreviousPage 이전 페이지 존재 여부
+ * Offset을 사용한 페이지네이션 인터페이스입니다.
  */
-export interface Pagination {
+export interface OffsetPagination {
+  type: 'offset'
   page: number
   limit: number
   total: number
   totalPages: number
-  hasNextPage: boolean
-  hasPreviousPage: boolean
+  hasNext: boolean
+  hasPrev: boolean
 }
 
 /**
- * API 응답의 기본 구조를 정의하는 제네릭 인터페이스입니다.
- * @template T 응답 데이터의 타입
- * @property success 요청 성공 여부
- * @property data 응답 데이터
- * @property [pagination] 페이지네이션 정보(Optional)
+ * Cursor를 사용한 페이지네이션 인터페이스입니다.
  */
-export interface ApiResponse<T> {
-  success: boolean
+export interface CursorPagination {
+  type: 'cursor'
+  hasNext: boolean
+  hasPrev?: boolean
+  nextCursor?: string
+  prevCursor?: string
+}
+
+/**
+ * 성공적인 응답 형식입니다.
+ */
+export interface SuccessResponse<T> {
+  success: true
   data: T
-  pagination?: Pagination
+  message?: string
+  pagination?: OffsetPagination | CursorPagination
 }
 
 /**
- * 성공적인 API 응답을 전송하는 함수입니다.
- *
- * @template T 응답 데이터의 타입
- * @param res Express Response 객체
- * @param data 응답으로 보낼 데이터
- * @param [pagination] 페이지네이션 정보(선택적, page/limit/total만 입력)
- * @returns API 응답이 담긴 Express Response 객체
- *
- * @example
- * sendSuccess(res, users, { page: 1, limit: 10, total: 100 });
+ * 오류 응답 형식입니다.
  */
-export function sendSuccess<T>(
+export interface ErrorResponse {
+  success: false
+  message: string
+  code?: string
+  details?: any
+}
+
+/**
+ * 성공적인 응답을 반환하는 함수입니다.
+ * @param res - Express 응답 객체
+ * @param data - 응답 데이터
+ * @param options - 선택적 메시지와 페이지네이션 정보
+ * @returns Express 응답 객체
+ * @example
+ * // 데이터만 반환하는 경우
+ * success(res, { id: 1, name: 'Junwoo Park' })
+ *
+ * // 데이터와 메시지를 반환하는 경우
+ * success(res, { id: 1, name: 'Junwoo Park' }, { message: 'User created successfully' })
+ *
+ * // 데이터와 페이지네이션 정보를 반환하는 경우
+ * `successWithOffset()` 이나 `successWithCursor()` 함수를 사용하세요.
+ */
+export function success<T>(
   res: Response,
   data: T,
-  pagination?: { page: number; limit: number; total: number },
-): Response<ApiResponse<T>> {
-  return res.status(200).json({
+  options?: {
+    message?: string
+    pagination?: OffsetPagination | CursorPagination
+  },
+): Response<SuccessResponse<T>> {
+  return res.json({
     success: true,
     data,
-    pagination: pagination
-      ? {
-          page: pagination.page,
-          limit: pagination.limit,
-          total: pagination.total,
-          totalPages: Math.ceil(pagination.total / pagination.limit),
-          hasNextPage: pagination.page * pagination.limit < pagination.total,
-          hasPreviousPage: pagination.page > 1,
-        }
-      : undefined,
+    ...options,
   })
 }
 
 /**
- * 에러 응답을 전송하는 함수입니다.
- *
- * @param res Express Response 객체
- * @param message 에러 메시지
- * @param [statusCode=200] HTTP 상태 코드(기본값: 200)
- * @returns API 에러 응답이 담긴 Express Response 객체
- *
+ * Offset 페이지네이션을 사용하여 성공적인 응답을 반환하는 함수입니다.
+ * @param res - Express 응답 객체
+ * @param data - 응답 데이터
+ * @param options - 페이지, 한 페이지당 항목 수, 총 항목 수, 선택적 메시지
+ * @return Express 응답 객체
  * @example
- * sendError(res, '잘못된 요청입니다.', 400);
+ * // 페이지네이션된 데이터와 함께 응답
+ * successWithOffset(res, articles, {
+ *   page: 1,
+ *   limit: 10,
+ *   total: 100,
+ *   message: 'Articles retrieved successfully',
+ *   })
  */
-export function sendError(res: Response, message: string, statusCode: number = 200): Response<ApiResponse<null>> {
+export function successWithOffset<T>(
+  res: Response,
+  data: T,
+  options: {
+    page: number
+    limit: number
+    total: number
+    message?: string
+  },
+) {
+  const pagination: OffsetPagination = {
+    type: 'offset',
+    page: options.page,
+    limit: options.limit,
+    total: options.total,
+    totalPages: Math.ceil(options.total / options.limit),
+    hasNext: options.page * options.limit < options.total,
+    hasPrev: options.page > 1,
+  }
+
+  return success(res, data, {
+    message: options.message,
+    pagination,
+  })
+}
+
+/**
+ * Cursor 페이지네이션을 사용하여 성공적인 응답을 반환하는 함수입니다.
+ * @param res - Express 응답 객체
+ * @param data - 응답 데이터
+ * @param options - 다음 페이지 여부, 이전 페이지 여부, 다음 커서, 이전 커서, 선택적 메시지
+ * @return Express 응답 객체
+ * @example
+ * // 커서 페이지네이션된 데이터와 함께 응답
+ * successWithCursor(res, articles, {
+ *  hasNext: true,
+ *  hasPrev: false,
+ *  nextCursor: 'eyJjcmVhdGVkQXQiOiIyMDIzLTA5LTIxVDEyOjAwOjAwLjAwMFoiLCJpZCI6MX0=',
+ *  prevCursor: undefined,
+ *  message: 'Articles retrieved successfully',
+ *  })
+ */
+export function successWithCursor<T>(
+  res: Response,
+  data: T,
+  options: {
+    hasNext: boolean
+    hasPrev?: boolean
+    nextCursor?: string
+    prevCursor?: string
+    message?: string
+  },
+) {
+  const pagination: CursorPagination = {
+    type: 'cursor',
+    hasNext: options.hasNext,
+    hasPrev: options.hasPrev,
+    nextCursor: options.nextCursor,
+    prevCursor: options.prevCursor,
+  }
+
+  return success(res, data, {
+    message: options.message,
+    pagination,
+  })
+}
+
+/**
+ * 오류 응답을 반환하는 함수입니다.
+ * @param res - Express 응답 객체
+ * @param message - 오류 메시지
+ * @param statusCode - HTTP 상태 코드 (기본값: 400)
+ * @param options - 선택적 오류 세부 정보
+ * @return Express 응답 객체
+ * @example
+ * // 오류 메시지와 상태 코드를 반환하는 경우
+ * error(res, 'Invalid request', 400)
+ */
+export function error(
+  res: Response,
+  message: string,
+  statusCode: number = 400,
+  options?: {
+    details?: any
+  },
+): Response<ErrorResponse> {
   return res.status(statusCode).json({
     success: false,
-    data: message,
+    message,
+    ...options,
   })
+}
+
+/**
+ * 오류 응답을 반환하는 유틸리티 객체입니다.
+ * 각 HTTP 상태 코드에 대한 오류 응답을 간편하게 반환할 수 있는 메서드를 제공합니다.
+ */
+export const errors = {
+  badRequest: (res: Response, message: string = 'Bad Request') => error(res, message, 400),
+  unauthorized: (res: Response, message: string = 'Unauthorized') => error(res, message, 401),
+  forbidden: (res: Response, message: string = 'Forbidden') => error(res, message, 403),
+  notFound: (res: Response, message: string = 'Not Found') => error(res, message, 404),
+  conflict: (res: Response, message: string = 'Conflict') => error(res, message, 409),
+  internal: (res: Response, message: string = 'Internal Server Error') => error(res, message, 500),
 }


### PR DESCRIPTION
# Changelog
- `success()`를 사용하여 기본 200 응답을 반환하도록 설정하였습니다.
- `successWithOffset()`을 사용하여 Offset Pagination 응답을 반환하도록 하였습니다.
- `successWithCursor()`를 사용하여 Cursor Pagination 응답을 반환하도록 하였습니다.
- `errors.*` 를 사용하여 자주 사용되는 오류에 대해 기본 메시지를 상태 코드를 반환하도록 하였습니다.

- 기존에 `sendSuccess()` 와 `sendError()`를 사용하는 코드들을 수정하고, 테스트코드도 수정하였습니다.

# Testing
<img width="664" height="412" alt="image" src="https://github.com/user-attachments/assets/6d2934ab-8007-4548-b07e-6a6aec8973c9" />

# Ops Impact
N/A

# Version Compatibility
N/A