### PR TITLE
[Terraform] Gemini 모델 변경

### DIFF
--- a/terraform/cluster_summarizer.tf
+++ b/terraform/cluster_summarizer.tf
@@ -12,7 +12,7 @@ module "cluster_summarizer" {
   max_instance_count  = 20
   environment_variables = {
     PROJECT_ID                = var.project
-    VERTEX_AI_REGION          = "us-central1" # Gemini 2.5 is only available in us-central1
+    VERTEX_AI_REGION          = "global"
     INSTANCE_CONNECTION_NAME  = google_sql_database_instance.mysql.connection_name
     MYSQL_SUMMARIZER_USERNAME = data.google_secret_manager_secret_version.mysql_summarizer_username.secret_data
     MYSQL_SUMMARIZER_PASSWORD = data.google_secret_manager_secret_version.mysql_summarizer_password.secret_data

--- a/terraform/src/cluster_summarizer/main.py
+++ b/terraform/src/cluster_summarizer/main.py
@@ -290,7 +290,7 @@ class VertexAiClient:
     """Client for interacting with Vertex AI for content generation."""
 
     # Constants for better maintainability
-    MODEL_NAME = "google/gemini-2.5-pro-preview-05-06"
+    MODEL_NAME = "google/gemini-2.5-pro"
     VALID_SECTIONS = [
         "politics", "economy", "society", "culture", "tech", "world"
     ]


### PR DESCRIPTION
# Changelog
- 기존에 사용하고 있던 `gemini-2.5-preview`가 사라지고, 정식 `gemini-2.5`가 출시됨에 따라 Summarizer에 다음과 같은 오류가 발생하였습니다.
- 모델을 `gemini-2.5-pro` 로 변경하였습니다.
<img width="1108" height="486" alt="image" src="https://github.com/user-attachments/assets/47596f43-ac01-4e2f-9016-ce873092352e" />

# Testing
- Workflow를 Trigger하여 정상 작동 여부 테스트
<img width="1147" height="664" alt="image" src="https://github.com/user-attachments/assets/3af5781c-095c-4788-bb66-8c24c47792d2" />

# Ops Impact
N/A

# Version Compatibility
N/A