### PR TITLE
[Server] 뉴스 관련 Controller, Service 구현

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "bcrypt": "^6.0.0",
+    "dayjs": "^1.11.13",
     "express": "^4.21.0",
     "jsonwebtoken": "^9.0.2",
     "string-hash": "^1.1.3",

--- a/server/pnpm-lock.yaml
+++ b/server/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       bcrypt:
         specifier: ^6.0.0
         version: 6.0.0
+      dayjs:
+        specifier: ^1.11.13
+        version: 1.11.13
       express:
         specifier: ^4.21.0
         version: 4.21.2
@@ -867,6 +870,9 @@ packages:
 
   date-fns@4.1.0:
     resolution: {integrity: sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==}
+
+  dayjs@1.11.13:
+    resolution: {integrity: sha512-oaMBel6gjolK862uaPQOVTA7q3TZhuSvuMQAAglQDOWYO9A91IrAOUJEyKVlqJlHE0vq5p5UXxzdPfMH/x6xNg==}
 
   debug@2.6.9:
     resolution: {integrity: sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==}
@@ -2947,6 +2953,8 @@ snapshots:
       which: 2.0.2
 
   date-fns@4.1.0: {}
+
+  dayjs@1.11.13: {}
 
   debug@2.6.9:
     dependencies:

--- a/server/src/controllers/__tests__/articleController.test.ts
+++ b/server/src/controllers/__tests__/articleController.test.ts
@@ -1,0 +1,107 @@
+import { getArticles, getArticleById } from '../articleController'
+import { articleService } from '../../services/articleService'
+import { successWithCursor, success, errors } from '../../utils/response'
+
+jest.mock('../../services/articleService')
+jest.mock('../../utils/response')
+
+const mockSuccessWithCursor = successWithCursor as jest.Mock
+const mockSuccess = success as jest.Mock
+const mockInternalError = errors.internal as jest.Mock
+
+describe('articleController', () => {
+  let req: any
+  let res: any
+
+  beforeEach(() => {
+    req = { query: {}, params: {} }
+    res = {}
+    mockSuccessWithCursor.mockReset()
+    mockSuccess.mockReset()
+    mockInternalError.mockReset()
+  })
+
+  describe('getArticles', () => {
+    it('should call service and respond with successWithCursor on success', async () => {
+      req.query.limit = '20'
+      req.query.cursor = 'abc'
+      const mockResult = {
+        data: [{ id: 1, title: 'news' }],
+        hasNext: true,
+        nextCursor: 'zzz',
+      }
+      ;(articleService.getArticlesByCursor as jest.Mock).mockResolvedValue(mockResult)
+
+      await getArticles(req as any, res as any)
+
+      expect(articleService.getArticlesByCursor).toHaveBeenCalledWith(20, 'abc')
+      expect(mockSuccessWithCursor).toHaveBeenCalledWith(res, mockResult.data, { hasNext: true, nextCursor: 'zzz' })
+    })
+
+    it('should use fallback limit 10 if not specified in query', async () => {
+      // req.query.limit not set
+      req.query.cursor = undefined
+      const mockResult = {
+        data: [{ id: 1 }],
+        hasNext: false,
+        nextCursor: undefined,
+      }
+      ;(articleService.getArticlesByCursor as jest.Mock).mockResolvedValue(mockResult)
+
+      await getArticles(req, res)
+
+      expect(articleService.getArticlesByCursor).toHaveBeenCalledWith(10, undefined)
+      expect(mockSuccessWithCursor).toHaveBeenCalledWith(res, mockResult.data, {
+        hasNext: false,
+        nextCursor: undefined,
+      })
+    })
+
+    it('should respond with internal error on service exception', async () => {
+      req.query.limit = '10'
+      req.query.cursor = 'fail'
+      const error = new Error('fail')
+      ;(articleService.getArticlesByCursor as jest.Mock).mockRejectedValue(error)
+
+      await getArticles(req, res)
+
+      expect(articleService.getArticlesByCursor).toHaveBeenCalled()
+      expect(mockInternalError).toHaveBeenCalledWith(res)
+      expect(mockSuccessWithCursor).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('getArticleById', () => {
+    it('should get article and call success on success', async () => {
+      req.params.id = '42'
+      const article = { id: 42, title: 'test' }
+      ;(articleService.getArticleById as jest.Mock).mockResolvedValue(article)
+
+      await getArticleById(req, res)
+
+      expect(articleService.getArticleById).toHaveBeenCalledWith(42)
+      expect(mockSuccess).toHaveBeenCalledWith(res, article, {
+        message: 'Article retrieved successfully',
+      })
+    })
+
+    it('should parse id as integer', async () => {
+      req.params.id = '3'
+      const article = { id: 3 }
+      ;(articleService.getArticleById as jest.Mock).mockResolvedValue(article)
+
+      await getArticleById(req, res)
+
+      expect(articleService.getArticleById).toHaveBeenCalledWith(3)
+      expect(mockSuccess).toHaveBeenCalled()
+    })
+
+    it('should respond with internal error on service exception', async () => {
+      req.params.id = '100'
+      ;(articleService.getArticleById as jest.Mock).mockRejectedValue(new Error('err'))
+      await getArticleById(req, res)
+      expect(mockInternalError).toHaveBeenCalledWith(res)
+      expect(mockSuccess).not.toHaveBeenCalled()
+    })
+  })
+})

--- a/server/src/services/__tests__/articleService.test.ts
+++ b/server/src/services/__tests__/articleService.test.ts
@@ -1,0 +1,311 @@
+import { ProcessedArticle } from '@prisma/client'
+import { prismaMock } from '../../../prisma/mock'
+import { articleService, ArticleNotFoundError } from '../articleService'
+import { createCursor, decodeCursor } from '../../utils/cursor'
+import dayjs from 'dayjs'
+
+jest.mock('../../utils/cursor', () => ({
+  createCursor: jest.fn(),
+  decodeCursor: jest.fn(),
+}))
+
+const mockCreateCursor = createCursor as jest.MockedFunction<typeof createCursor>
+const mockDecodeCursor = decodeCursor as jest.MockedFunction<typeof decodeCursor>
+
+describe('ArticleService', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  describe('getArticlesByCursor', () => {
+    const mockArticle1: ProcessedArticle = {
+      id: 1,
+      title: 'Test Article 1',
+      one_line_summary: 'Summary 1',
+      full_summary: 'Full summary 1',
+      language: 'ko',
+      region: 'KR',
+      section: 'tech',
+      created_at: new Date('2025-07-17T00:00:00Z'),
+    }
+
+    const mockArticle2: ProcessedArticle = {
+      id: 2,
+      title: 'Test Article 2',
+      one_line_summary: 'Summary 2',
+      full_summary: 'Full summary 2',
+      language: 'en',
+      region: 'US',
+      section: 'business',
+      created_at: new Date('2025-07-18T00:00:00Z'),
+    }
+
+    const mockArticle3: ProcessedArticle = {
+      id: 3,
+      title: 'Test Article 3',
+      one_line_summary: 'Summary 3',
+      full_summary: 'Full summary 3',
+      language: 'ko',
+      region: null,
+      section: null,
+      created_at: new Date('2025-07-19T00:00:00Z'),
+    }
+
+    describe('When cursor is NOT provided', () => {
+      it('Fetches articles from the last 24 hours and there is a next page', async () => {
+        const limit = 2
+        const mockArticles = [mockArticle1, mockArticle2, mockArticle3]
+
+        prismaMock.processedArticle.findMany.mockResolvedValue(mockArticles)
+        mockCreateCursor.mockReturnValue('next-cursor')
+
+        const result = await articleService.getArticlesByCursor(limit)
+
+        expect(prismaMock.processedArticle.findMany).toHaveBeenCalledWith({
+          where: {
+            OR: [
+              { created_at: { gt: expect.any(Date) } },
+              { created_at: expect.any(Date), id: { gt: Number.MIN_SAFE_INTEGER } },
+            ],
+          },
+          orderBy: [{ created_at: 'asc' }, { id: 'asc' }],
+          take: limit + 1,
+        })
+
+        // Check if the date is from 24 hours ago
+        // const calledArgs = prismaMock.processedArticle.findMany.mock.calls[0][0]
+        // const expectedDate = dayjs().subtract(24, 'hour')
+        // const actualDate = dayjs(calledArgs.where.OR[0].created_at.gt)
+        // expect(Math.abs(expectedDate.diff(actualDate, 'minute'))).toBeLessThan(1)
+
+        expect(mockCreateCursor).toHaveBeenCalledWith(mockArticle2.created_at, mockArticle2.id)
+        expect(result).toEqual({
+          data: [mockArticle1, mockArticle2],
+          hasNext: true,
+          nextCursor: 'next-cursor',
+        })
+      })
+
+      it('Fetches from the last 24 hours and there is no next page', async () => {
+        const limit = 3
+        const mockArticles = [mockArticle1, mockArticle2]
+
+        prismaMock.processedArticle.findMany.mockResolvedValue(mockArticles)
+
+        const result = await articleService.getArticlesByCursor(limit)
+
+        expect(result).toEqual({
+          data: [mockArticle1, mockArticle2],
+          hasNext: false,
+          nextCursor: undefined,
+        })
+        expect(mockCreateCursor).not.toHaveBeenCalled()
+      })
+
+      it('Returns empty result set', async () => {
+        const limit = 2
+
+        prismaMock.processedArticle.findMany.mockResolvedValue([])
+
+        const result = await articleService.getArticlesByCursor(limit)
+
+        expect(result).toEqual({
+          data: [],
+          hasNext: false,
+          nextCursor: undefined,
+        })
+        expect(mockCreateCursor).not.toHaveBeenCalled()
+      })
+    })
+
+    describe('When cursor is provided', () => {
+      const mockCursor = 'test-cursor'
+      const decodedCursor = {
+        createdAt: new Date('2024-01-01T12:00:00Z'),
+        id: 5,
+      }
+
+      beforeEach(() => {
+        mockDecodeCursor.mockReturnValue(decodedCursor)
+      })
+
+      it('Decodes the cursor, fetches with the correct condition, and there is a next page', async () => {
+        const limit = 2
+        const mockArticles = [mockArticle1, mockArticle2, mockArticle3]
+
+        prismaMock.processedArticle.findMany.mockResolvedValue(mockArticles)
+        mockCreateCursor.mockReturnValue('next-cursor')
+
+        const result = await articleService.getArticlesByCursor(limit, mockCursor)
+
+        expect(mockDecodeCursor).toHaveBeenCalledWith(mockCursor)
+        expect(prismaMock.processedArticle.findMany).toHaveBeenCalledWith({
+          where: {
+            OR: [
+              { created_at: { gt: decodedCursor.createdAt } },
+              { created_at: decodedCursor.createdAt, id: { gt: decodedCursor.id } },
+            ],
+          },
+          orderBy: [{ created_at: 'asc' }, { id: 'asc' }],
+          take: limit + 1,
+        })
+
+        expect(mockCreateCursor).toHaveBeenCalledWith(mockArticle2.created_at, mockArticle2.id)
+        expect(result).toEqual({
+          data: [mockArticle1, mockArticle2],
+          hasNext: true,
+          nextCursor: 'next-cursor',
+        })
+      })
+
+      it('Decodes the cursor, fetches, and there is no next page', async () => {
+        const limit = 3
+        const mockArticles = [mockArticle1, mockArticle2]
+
+        prismaMock.processedArticle.findMany.mockResolvedValue(mockArticles)
+
+        const result = await articleService.getArticlesByCursor(limit, mockCursor)
+
+        expect(mockDecodeCursor).toHaveBeenCalledWith(mockCursor)
+        expect(result).toEqual({
+          data: [mockArticle1, mockArticle2],
+          hasNext: false,
+          nextCursor: undefined,
+        })
+        expect(mockCreateCursor).not.toHaveBeenCalled()
+      })
+
+      it('Returns exactly the limit number of articles and there is no next page', async () => {
+        const limit = 2
+        const mockArticles = [mockArticle1, mockArticle2]
+
+        prismaMock.processedArticle.findMany.mockResolvedValue(mockArticles)
+
+        const result = await articleService.getArticlesByCursor(limit, mockCursor)
+
+        expect(result).toEqual({
+          data: [mockArticle1, mockArticle2],
+          hasNext: false,
+          nextCursor: undefined,
+        })
+        expect(mockCreateCursor).not.toHaveBeenCalled()
+      })
+    })
+
+    describe('Exception cases', () => {
+      it('Throws error when Prisma returns an error', async () => {
+        const error = new Error('Database connection failed')
+        prismaMock.processedArticle.findMany.mockRejectedValue(error)
+
+        await expect(articleService.getArticlesByCursor(10)).rejects.toThrow('Database connection failed')
+      })
+
+      it('Throws error when cursor decoding fails', async () => {
+        const invalidCursor = 'invalid-cursor'
+        const decodingError = new Error('Invalid cursor format')
+
+        mockDecodeCursor.mockImplementation(() => {
+          throw decodingError
+        })
+
+        await expect(articleService.getArticlesByCursor(10, invalidCursor)).rejects.toThrow('Invalid cursor format')
+
+        expect(mockDecodeCursor).toHaveBeenCalledWith(invalidCursor)
+        expect(prismaMock.processedArticle.findMany).not.toHaveBeenCalled()
+      })
+
+      it('Throws error when createCursor throws', async () => {
+        const limit = 2
+        const mockArticles = [mockArticle1, mockArticle2, mockArticle3]
+
+        prismaMock.processedArticle.findMany.mockResolvedValue(mockArticles)
+        mockCreateCursor.mockImplementation(() => {
+          throw new Error('Cursor creation failed')
+        })
+
+        await expect(articleService.getArticlesByCursor(limit)).rejects.toThrow('Cursor creation failed')
+      })
+    })
+  })
+
+  describe('getArticleById', () => {
+    const mockArticle: ProcessedArticle = {
+      id: 1,
+      title: 'Test Article',
+      one_line_summary: 'Test summary',
+      full_summary: 'Test full summary',
+      language: 'ko',
+      region: 'KR',
+      section: 'tech',
+      created_at: new Date('2024-01-01T00:00:00Z'),
+    }
+
+    it('Successfully fetches an article with an existing ID', async () => {
+      const articleId = 1
+      prismaMock.processedArticle.findUnique.mockResolvedValue(mockArticle)
+
+      const result = await articleService.getArticleById(articleId)
+
+      expect(prismaMock.processedArticle.findUnique).toHaveBeenCalledWith({
+        where: { id: articleId },
+      })
+      expect(result).toEqual(mockArticle)
+    })
+
+    it('Throws ArticleNotFoundError when querying with a non-existing ID', async () => {
+      const articleId = 999
+      prismaMock.processedArticle.findUnique.mockResolvedValue(null)
+
+      await expect(articleService.getArticleById(articleId)).rejects.toThrow(ArticleNotFoundError)
+
+      await expect(articleService.getArticleById(articleId)).rejects.toThrow(`Article with ID ${articleId} not found`)
+
+      expect(prismaMock.processedArticle.findUnique).toHaveBeenCalledWith({
+        where: { id: articleId },
+      })
+    })
+
+    it('Throws error when Prisma returns an error', async () => {
+      const articleId = 1
+      const error = new Error('Database connection failed')
+      prismaMock.processedArticle.findUnique.mockRejectedValue(error)
+
+      await expect(articleService.getArticleById(articleId)).rejects.toThrow('Database connection failed')
+    })
+
+    it('Checks that method is called properly for a range of IDs', async () => {
+      const testIds = [0, 1, 100, 999999]
+
+      prismaMock.processedArticle.findUnique.mockResolvedValue(mockArticle)
+
+      for (const id of testIds) {
+        await articleService.getArticleById(id)
+        expect(prismaMock.processedArticle.findUnique).toHaveBeenCalledWith({
+          where: { id },
+        })
+      }
+
+      expect(prismaMock.processedArticle.findUnique).toHaveBeenCalledTimes(testIds.length)
+    })
+  })
+
+  describe('ArticleNotFoundError', () => {
+    it('Should have correct name and message', () => {
+      const message = 'Test error message'
+      const error = new ArticleNotFoundError(message)
+
+      expect(error).toBeInstanceOf(Error)
+      expect(error).toBeInstanceOf(ArticleNotFoundError)
+      expect(error.name).toBe('ArticleNotFoundError')
+      expect(error.message).toBe(message)
+    })
+
+    it('Should be distinguishable from other Error instances', () => {
+      const articleError = new ArticleNotFoundError('Article not found')
+      const genericError = new Error('Generic error')
+
+      expect(articleError).not.toEqual(genericError)
+      expect(articleError.name).not.toBe(genericError.name)
+    })
+  })
+})

--- a/server/src/services/articleService.ts
+++ b/server/src/services/articleService.ts
@@ -1,0 +1,99 @@
+import { ProcessedArticle } from '@prisma/client'
+import { prisma } from '../../prisma/prisma'
+import { createCursor, decodeCursor } from '../utils/cursor'
+import dayjs from 'dayjs'
+
+/**
+ * 커서 페이지네이션을 사용하여 기사를 조회하는 결과 형식입니다.
+ */
+export interface ArticleCursorPaginationResult {
+  data: ProcessedArticle[]
+  hasNext: boolean
+  nextCursor?: string
+}
+
+/**
+ * 특정 ID의 기사를 찾지 못했을 때 발생하는 오류 클래스입니다.
+ * 이 오류는 기사가 존재하지 않을 때 사용됩니다.
+ */
+export class ArticleNotFoundError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'ArticleNotFoundError'
+  }
+}
+
+export const articleService = {
+  /**
+   * Cursor 페이지네이션을 사용하여 기사를 조회합니다.
+   * 이 함수는 주어진 limit와 cursor를 사용하여 기사를 조회하고, 다음 커서를 반환합니다.
+   * 만약 cursor가 주어지지 않으면, 기본적으로 24시간 이전의 기사를 조회합니다.
+   * @param limit - 조회할 기사 수의 제한
+   * @param cursor - 다음 페이지를 위한 커서 (선택적)
+   * @return ArticleCursorPaginationResult - 조회된 기사와 다음 커서 정보
+   * @example
+   * // 커서 페이지네이션을 사용하여 기사를 조회
+   * getArticlesByCursor(10, 'eyJjcmVhdGVkQXQiOiIyMDIzLTA5LTIxVDEyOjAwOjAwLjAwMFoiLCJpZCI6MX0=')
+   * // 반환값: { data: [...], hasNext: true, nextCursor: 'eyJj...' }
+   */
+  getArticlesByCursor: async (limit: number, cursor?: string): Promise<ArticleCursorPaginationResult> => {
+    let createdAt: Date
+    let id: number
+
+    if (cursor) {
+      const decodedCursor = decodeCursor(cursor)
+      createdAt = decodedCursor.createdAt
+      id = decodedCursor.id
+    } else {
+      // cursor가 존재하지 않는 경우 24시간 이전으로 설정
+      createdAt = dayjs().subtract(24, 'hour').toDate()
+      id = Number.MIN_SAFE_INTEGER
+    }
+
+    const articles = await prisma.processedArticle.findMany({
+      where: {
+        OR: [{ created_at: { gt: createdAt } }, { created_at: createdAt, id: { gt: id } }],
+      },
+      orderBy: [{ created_at: 'asc' }, { id: 'asc' }],
+      take: limit + 1,
+    })
+
+    const hasNext = articles.length > limit
+    const data = hasNext ? articles.slice(0, -1) : articles
+
+    let nextCursor: string | undefined
+    if (hasNext && data.length > 0) {
+      const lastArticle = data[data.length - 1]
+      nextCursor = createCursor(lastArticle.created_at, lastArticle.id)
+    }
+
+    return {
+      data,
+      hasNext,
+      nextCursor,
+    }
+  },
+
+  /**
+   * 특정 ID의 기사를 조회합니다.
+   * 기사가 존재하지 않을 경우 ArticleNotFoundError를 발생시킵니다.
+   * @param id - 조회할 기사의 ID
+   * @return ProcessedArticle - 조회된 기사 객체
+   * @throws {ArticleNotFoundError} - 기사가 존재하지 않을 경우
+   * @example
+   * // 특정 ID의 기사를 조회
+   * getArticleById(1)
+   * // 반환값: ProcessedArticle 객체
+   */
+  getArticleById: async (id: number): Promise<ProcessedArticle> => {
+    const article = await prisma.processedArticle.findUnique({
+      where: { id },
+    })
+
+    if (!article) {
+      throw new ArticleNotFoundError(`Article with ID ${id} not found`)
+    }
+
+    return article
+  },
+}


### PR DESCRIPTION
# Changelog
- `/api/articles?limit={개수제한}&cursor={시간,ID}`
  - 복수개의 뉴스를 가져오는 경우 Cursor Pagination을 통해 데이터를 가져오도록 구현하였습니다.
  - Cursor는 현재까지 가져온 뉴스 중 가장 마지막 뉴스의 `created_at`과 `id`를 포함하는 base64 인코딩 된 문자열입니다.
  - Cursor가 주어지지 않은 경우 현재 시간 기준 24시간 전 뉴스부터 차례대로 가져옵니다.

- `/api/articles/:id`: 특정 ID의 뉴스를 가져옵니다.

# Testing
<img width="695" height="469" alt="image" src="https://github.com/user-attachments/assets/0e207232-4849-41ae-be51-437e9f9a032d" />

- 커서가 주어지지 않은 경우 처음부터 반환
<img width="1001" height="886" alt="image" src="https://github.com/user-attachments/assets/4550d6b3-165b-44f2-a9c0-81d20f80a971" />

- ID=1의 커서가 주어진 경우 -> ID=2 뉴스 반환
<img width="1009" height="894" alt="image" src="https://github.com/user-attachments/assets/d1cfa056-4c5b-45b5-95da-590247294542" />

# Ops Impact
N/A

# Version Compatibility
N/A