### PR TITLE
[Server] 사용자의 조회 기록을 저장하는 DB 및 API 구현

### DIFF
--- a/server/prisma/migrations/20250723141309_view_event/migration.sql
+++ b/server/prisma/migrations/20250723141309_view_event/migration.sql
@@ -1,0 +1,15 @@
+-- CreateTable
+CREATE TABLE `view_event` (
+    `p_article_id` INTEGER NOT NULL,
+    `user_id` INTEGER NOT NULL,
+    `event_type` ENUM('impression', 'detail') NOT NULL,
+    `created_at` DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+
+    PRIMARY KEY (`p_article_id`, `user_id`, `event_type`)
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+-- AddForeignKey
+ALTER TABLE `view_event` ADD CONSTRAINT `view_event_p_article_id_fkey` FOREIGN KEY (`p_article_id`) REFERENCES `processed_article`(`id`) ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE `view_event` ADD CONSTRAINT `view_event_user_id_fkey` FOREIGN KEY (`user_id`) REFERENCES `user`(`id`) ON DELETE CASCADE ON UPDATE CASCADE;

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -26,10 +26,11 @@ model ProcessedArticle {
   section          String?  @db.VarChar(30)
   created_at       DateTime @default(now())
 
-  articles Article[]
-  keywords KeywordArticleMapping[]
-  likes    Like[]
-  scraps   Scrap[]
+  articles  Article[]
+  keywords  KeywordArticleMapping[]
+  likes     Like[]
+  scraps    Scrap[]
+  ViewEvent ViewEvent[]
 
   @@map("processed_article")
 }
@@ -85,6 +86,7 @@ model User {
   refreshTokens RefreshToken?
   likes         Like[]
   scraps        Scrap[]
+  ViewEvent     ViewEvent[]
 
   @@map("user")
 }
@@ -125,4 +127,22 @@ model Scrap {
 
   @@id([p_article_id, user_id])
   @@map("scrap")
+}
+
+enum ViewEventType {
+  impression // 그냥 스크롤 노출
+  detail // 자세히 보기
+}
+
+model ViewEvent {
+  p_article_id Int
+  user_id      Int
+  event_type   ViewEventType
+  created_at   DateTime      @default(now())
+
+  processed_article ProcessedArticle @relation(fields: [p_article_id], references: [id], onDelete: Cascade)
+  user              User             @relation(fields: [user_id], references: [id], onDelete: Cascade)
+
+  @@id([p_article_id, user_id, event_type])
+  @@map("view_event")
 }

--- a/server/src/controllers/articleController.ts
+++ b/server/src/controllers/articleController.ts
@@ -1,6 +1,8 @@
 import { Request, Response } from 'express'
 import { errors, success, successWithCursor } from '../utils/response'
 import { ArticleCursorPaginationResult, ArticleNotFoundError, articleService } from '../services/articleService'
+import { AuthenticatedRequest } from '../middlewares/authenticateJWT'
+import { ViewEventType } from '@prisma/client'
 
 /**
  * Cursor 기반 페이지네이션을 사용하여 기사 목록을 가져오는 컨트롤러입니다.
@@ -71,6 +73,47 @@ export const getArticleById = async (req: Request, res: Response) => {
     if (error instanceof ArticleNotFoundError) {
       return errors.notFound(res, 'Article not found')
     }
+    return errors.internal(res)
+  }
+}
+
+/**
+ * 사용자가 특정 기사를 조회할 때 발생하는 이벤트를 기록하는 컨트롤러입니다.
+ * 이 컨트롤러는 사용자의 ID와 기사 ID, 이벤트 유형을 받아 해당 이벤트를 데이터베이스에 기록합니다.
+ * @param {AuthenticatedRequest} req - 인증된 요청 객체. 사용자 ID와 body에 pArticleId, eventType이 포함되어야 합니다.
+ * @param {Response} res - Express 응답 객체.
+ * @example
+ * // 요청 예시
+ * POST /api/articles/view-event
+ * {
+ *   "pArticleId": 1,
+ *   "eventType": "VIEW"
+ *   }
+ * // 응답 예시
+ * {
+ *  "message": "View event recorded successfully"
+ *  }
+ */
+export const recordViewEvent = async (req: AuthenticatedRequest, res: Response) => {
+  const userId = req.userId
+  if (!userId) {
+    return errors.unauthorized(res, 'User ID is required')
+  }
+
+  const { pArticleId, eventType } = req.body
+  if (!pArticleId || !eventType) {
+    return errors.badRequest(res, 'pArticleId and eventType are required')
+  }
+
+  if (!Object.values(ViewEventType).includes(eventType)) {
+    return errors.badRequest(res, 'Invalid event type')
+  }
+
+  try {
+    await articleService.recordViewEvent(userId, pArticleId, eventType)
+    return success(res, null, { message: 'View event recorded successfully' })
+  } catch (error) {
+    console.error('Failed to record view event:', error)
     return errors.internal(res)
   }
 }

--- a/server/src/routes/article.ts
+++ b/server/src/routes/article.ts
@@ -1,5 +1,6 @@
 import { Router } from 'express'
-import { getArticles, getArticleById } from '../controllers/articleController'
+import { getArticles, getArticleById, recordViewEvent } from '../controllers/articleController'
+import { authenticateJWT } from '../middlewares/authenticateJWT'
 
 const router = Router()
 
@@ -14,5 +15,11 @@ router.get('/', getArticles)
  * GET /:id
  */
 router.get('/:id', getArticleById)
+
+/**
+ * 기사 조회 이벤트 기록
+ * POST /view-event
+ */
+router.post('/view-event', authenticateJWT, recordViewEvent)
 
 export default router

--- a/server/src/services/__tests__/articleService.test.ts
+++ b/server/src/services/__tests__/articleService.test.ts
@@ -1,4 +1,4 @@
-import { ProcessedArticle } from '@prisma/client'
+import { ProcessedArticle, ViewEventType } from '@prisma/client'
 import { prismaMock } from '../../../prisma/mock'
 import { articleService, ArticleNotFoundError } from '../articleService'
 import { createCursor, decodeCursor } from '../../utils/cursor'
@@ -306,6 +306,24 @@ describe('ArticleService', () => {
 
       expect(articleError).not.toEqual(genericError)
       expect(articleError.name).not.toBe(genericError.name)
+    })
+  })
+
+  describe('recordViewEvent', () => {
+    it('should call prisma.viewEvent.create with correct params', async () => {
+      const userId = 10
+      const pArticleId = 20
+      const eventType = ViewEventType.detail
+
+      await articleService.recordViewEvent(userId, pArticleId, eventType)
+
+      expect(prismaMock.viewEvent.create).toHaveBeenCalledWith({
+        data: {
+          user_id: userId,
+          p_article_id: pArticleId,
+          event_type: eventType,
+        },
+      })
     })
   })
 })

--- a/server/src/services/articleService.ts
+++ b/server/src/services/articleService.ts
@@ -1,4 +1,4 @@
-import { ProcessedArticle } from '@prisma/client'
+import { ProcessedArticle, ViewEventType } from '@prisma/client'
 import { prisma } from '../../prisma/prisma'
 import { createCursor, decodeCursor } from '../utils/cursor'
 import dayjs from 'dayjs'
@@ -95,5 +95,23 @@ export const articleService = {
     }
 
     return article
+  },
+
+  /**
+   * 사용자의 조회 이벤트를 기록합니다.
+   * 이 함수는 사용자가 특정 기사를 조회했을 때 이벤트를 기록합니다.
+   * @param userId - 조회 이벤트를 기록할 사용자의 ID
+   * @param pArticleId - 조회된 기사의 ID
+   * @param eventType - 이벤트 유형 (예: 'VIEW')
+   * @return Promise<void> - 이벤트 기록이 완료되면 반환되는 Promise
+   */
+  recordViewEvent: async (userId: number, pArticleId: number, eventType: ViewEventType) => {
+    await prisma.viewEvent.create({
+      data: {
+        user_id: userId,
+        p_article_id: pArticleId,
+        event_type: eventType,
+      },
+    })
   },
 }


### PR DESCRIPTION
# Changelog
- 사용자의 조회 기록 (단순한 스크롤 노출, 스와이프로 자세히 보기 등)을 기록하기 위한 `ViewEvent` 테이블을 생성하였습니다.
- 사용자의 ID를 JWT토큰에서 추출하고 body에서 기사의 ID와 eventType을 가져와 데이터베이스에 저장하는 `recordViewEvent`를 구현하였습니다.
- `recordViewEvent`를 `POST /api/articles/view-event` 에 매핑하였습니다.

# Testing
<img width="708" height="549" alt="image" src="https://github.com/user-attachments/assets/84b7997e-c4ec-446f-b026-3195cfa2f70b" />


# Ops Impact
N/A

# Version Compatibility
N/A