### PR TITLE
[Server] Swagger API Documentation 구성

### DIFF
--- a/server/build/swagger.yaml
+++ b/server/build/swagger.yaml
@@ -1,0 +1,367 @@
+openapi: 3.0.3
+info:
+  title: Somesup API Documentation
+  version: 1.0.0
+  description: |
+    썸즈업 API 문서입니다.
+servers:
+  - url: /api
+paths:
+  /auth/phone/request:
+    post:
+      summary: 휴대폰 번호 인증 요청
+      description: 사용자가 입력한 'phoneNumber'로 인증코드를 전송합니다.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PhoneRequest'
+      responses:
+        '200':
+          description: 인증코드 전송 성공
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SuccessMessageResponse'
+        '400':
+          description: 잘못된 요청 (phoneNumber 미입력)
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: 서버 오류
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  /auth/phone/verify:
+    post:
+      summary: 휴대폰 인증 코드 검증 및 회원 가입/로그인
+      description: |
+        인증코드가 맞으면 사용자 정보 및 JWT 토큰 발급. 신규 사용자는 회원가입 후 발급됨.
+        새로운 사용자는 랜덤 닉네임이 생성되어 회원가입되고, 이후 사용자는 닉네임을 변경할 수 있음.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PhoneVerifyRequest'
+      responses:
+        '200':
+          description: '인증 성공, 사용자 정보 및 액세스/리프레시 토큰 반환'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PhoneVerifySuccessResponse'
+        '400':
+          description: '잘못된 요청 (파라미터 누락, 인증코드 불일치 등)'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: 서버 오류
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  /auth/refresh:
+    post:
+      summary: 액세스 토큰 갱신
+      description: 유효한 리프레시 토큰을 이용해 새 액세스/리프레시 토큰을 발급합니다.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RefreshTokenRequest'
+      responses:
+        '200':
+          description: 토큰 갱신 성공
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TokenResponse'
+        '400':
+          description: 잘못된 요청 (refreshToken 미입력)
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '401':
+          description: 리프레시 토큰이 유효하지 않음
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '404':
+          description: 사용자 정보 없음
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: 서버 오류
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  /articles:
+    get:
+      summary: 기사 목록 조회 (Cursor 기반 페이지네이션)
+      description: limit 및 cursor 쿼리 파라미터를 이용해 기사를 조회합니다.
+      parameters:
+        - in: query
+          name: limit
+          schema:
+            type: integer
+            default: 10
+          description: 한 번에 조회할 기사 개수 (기본값 10)
+        - in: query
+          name: cursor
+          schema:
+            type: string
+          description: 커서 값 (이후 페이지 조회 시 사용)
+      responses:
+        '200':
+          description: 기사 목록 조회 성공
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ArticleCursorPaginationResponse'
+        '500':
+          description: 서버 오류
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  '/articles/{id}':
+    get:
+      summary: 특정 기사 조회
+      description: ID로 특정 기사를 조회합니다.
+      parameters:
+        - in: path
+          name: id
+          schema:
+            type: integer
+          required: true
+          description: 기사 ID
+      responses:
+        '200':
+          description: 기사 조회 성공
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ArticleResponse'
+        '404':
+          description: 기사 없음
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: 서버 오류
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+components:
+  schemas:
+    PhoneRequest:
+      type: object
+      required:
+        - phoneNumber
+      properties:
+        phoneNumber:
+          type: string
+          description: 휴대폰 번호
+          example: 01012345678
+    PhoneVerifyRequest:
+      type: object
+      required:
+        - phoneNumber
+        - code
+      properties:
+        phoneNumber:
+          type: string
+          description: 휴대폰 번호
+          example: 01012345678
+        code:
+          type: string
+          description: 인증 코드
+          example: '123456'
+    RefreshTokenRequest:
+      type: object
+      required:
+        - refreshToken
+      properties:
+        refreshToken:
+          type: string
+          description: 리프레시 토큰
+          example: your_refresh_token_here
+    SuccessMessageResponse:
+      type: object
+      properties:
+        success:
+          type: boolean
+          example: true
+        data:
+          type: 'null'
+          nullable: true
+          example: null
+        message:
+          type: string
+          example: Verification code sent successfully
+    PhoneVerifySuccessResponse:
+      type: object
+      properties:
+        success:
+          type: boolean
+          example: true
+        data:
+          type: object
+          properties:
+            user:
+              $ref: '#/components/schemas/User'
+            tokens:
+              $ref: '#/components/schemas/Tokens'
+        message:
+          type: string
+          example: Phone verification successful
+    TokenResponse:
+      type: object
+      properties:
+        success:
+          type: boolean
+          example: true
+        data:
+          $ref: '#/components/schemas/Tokens'
+        message:
+          type: string
+          example: Access token refreshed successfully
+    ErrorResponse:
+      type: object
+      properties:
+        success:
+          type: boolean
+          example: false
+        message:
+          type: string
+          example: Invalid verification code
+        code:
+          type: string
+          nullable: true
+          example: BAD_REQUEST
+        details:
+          type: object
+          nullable: true
+    User:
+      type: object
+      properties:
+        id:
+          type: integer
+          example: 1
+        phone:
+          type: string
+          example: 1012345678
+        nickname:
+          type: string
+          example: 슈퍼파워알파
+    Tokens:
+      type: object
+      properties:
+        accessToken:
+          type: string
+          example: <access_token>
+        refreshToken:
+          type: string
+          example: <refresh_token>
+    Article:
+      type: object
+      properties:
+        id:
+          type: integer
+          example: 1
+        provider_id:
+          type: integer
+          example: 2
+        processed_id:
+          type: integer
+          nullable: true
+          example: 10
+        title:
+          type: string
+          example: Example Article Title
+        content:
+          type: string
+          example: 기사 본문 내용입니다.
+        language:
+          type: string
+          example: ko
+        region:
+          type: string
+          nullable: true
+          example: Seoul
+        section:
+          type: string
+          nullable: true
+          example: politics
+        thumbnail_url:
+          type: string
+          example: 'https://example.com/image.jpg'
+        news_url:
+          type: string
+          example: 'https://news.example.com/article/1'
+        is_processed:
+          type: boolean
+          example: false
+        created_at:
+          type: string
+          format: date-time
+          example: '2023-09-21T12:00:00.000Z'
+    ArticleCursorPaginationResponse:
+      type: object
+      properties:
+        success:
+          type: boolean
+          example: true
+        data:
+          type: array
+          items:
+            $ref: '#/components/schemas/Article'
+        pagination:
+          type: object
+          properties:
+            type:
+              type: string
+              enum:
+                - cursor
+              example: cursor
+            hasNext:
+              type: boolean
+              example: true
+            hasPrev:
+              type: boolean
+              nullable: true
+              example: false
+            nextCursor:
+              type: string
+              nullable: true
+              example: eyJjcmVhdGVkQXQiOiIyMDIzLTA5LTIxVDEyOjAwOjAwLjAwMFoiLCJpZCI6Mn0=
+            prevCursor:
+              type: string
+              nullable: true
+              example: null
+    ArticleResponse:
+      type: object
+      properties:
+        success:
+          type: boolean
+          example: true
+        data:
+          $ref: '#/components/schemas/Article'
+        message:
+          type: string
+          example: Article retrieved successfully

--- a/server/build/swagger.yaml
+++ b/server/build/swagger.yaml
@@ -23,19 +23,38 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/SuccessMessageResponse'
+                $ref: '#/components/schemas/SuccessResponse'
+              examples:
+                success:
+                  summary: 인증코드 전송 성공
+                  value:
+                    success: true
+                    data: null
+                    message: Verification code sent successfully
         '400':
           description: 잘못된 요청 (phoneNumber 미입력)
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                invalidPhoneNumber:
+                  summary: 잘못된 휴대폰 번호
+                  value:
+                    success: false
+                    message: Phone number is required
         '500':
           description: 서버 오류
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                serverError:
+                  summary: 서버 오류
+                  value:
+                    success: false
+                    message: Internal server error
   /auth/phone/verify:
     post:
       summary: 휴대폰 인증 코드 검증 및 회원 가입/로그인
@@ -61,12 +80,34 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                missingParameters:
+                  summary: 파라미터 누락
+                  value:
+                    success: false
+                    message: Phone number and code are required
+                invalidCode:
+                  summary: 잘못된 인증 코드
+                  value:
+                    success: false
+                    message: Invalid verification code
+                codeExpired:
+                  summary: 인증 코드 만료
+                  value:
+                    success: false
+                    message: Verification code has expired
         '500':
           description: 서버 오류
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                serverError:
+                  summary: 서버 오류
+                  value:
+                    success: false
+                    message: Internal server error
   /auth/refresh:
     post:
       summary: 액세스 토큰 갱신
@@ -90,24 +131,53 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                missingRefreshToken:
+                  summary: 리프레시 토큰 누락
+                  value:
+                    success: false
+                    message: Refresh token is required
         '401':
-          description: 리프레시 토큰이 유효하지 않음
+          description: 리프레시 토큰이 유효하지 않거나 찾을 수 없음
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                invalidRefreshToken:
+                  summary: 유효하지 않은 리프레시 토큰
+                  value:
+                    success: false
+                    message: Invalid refresh token
+                refreshTokenNotFound:
+                  summary: 리프레시 토큰을 찾을 수 없음
+                  value:
+                    success: false
+                    message: Refresh token not found for the user
         '404':
           description: 사용자 정보 없음
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                userNotFound:
+                  summary: 사용자 정보 없음
+                  value:
+                    success: false
+                    message: User not found
         '500':
           description: 서버 오류
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                serverError:
+                  summary: 서버 오류
+                  value:
+                    success: false
+                    message: Internal server error
   /articles:
     get:
       summary: 기사 목록 조회 (Cursor 기반 페이지네이션)
@@ -137,6 +207,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                serverError:
+                  summary: 서버 오류
+                  value:
+                    success: false
+                    message: Internal server error
   '/articles/{id}':
     get:
       summary: 특정 기사 조회
@@ -161,12 +237,24 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                articleNotFound:
+                  summary: 기사를 찾을 수 없음
+                  value:
+                    success: false
+                    message: Article not found
         '500':
           description: 서버 오류
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                serverError:
+                  summary: 서버 오류
+                  value:
+                    success: false
+                    message: Internal server error
 components:
   schemas:
     PhoneRequest:
@@ -201,19 +289,6 @@ components:
           type: string
           description: 리프레시 토큰
           example: your_refresh_token_here
-    SuccessMessageResponse:
-      type: object
-      properties:
-        success:
-          type: boolean
-          example: true
-        data:
-          type: 'null'
-          nullable: true
-          example: null
-        message:
-          type: string
-          example: Verification code sent successfully
     PhoneVerifySuccessResponse:
       type: object
       properties:
@@ -241,6 +316,19 @@ components:
         message:
           type: string
           example: Access token refreshed successfully
+    SuccessResponse:
+      type: object
+      properties:
+        success:
+          type: boolean
+          example: true
+        data:
+          type: 'null'
+          nullable: true
+          example: null
+        message:
+          type: string
+          example: Verification code sent successfully
     ErrorResponse:
       type: object
       properties:
@@ -249,13 +337,12 @@ components:
           example: false
         message:
           type: string
-          example: Invalid verification code
+          example: Internal server error
         code:
           type: string
           nullable: true
-          example: BAD_REQUEST
         details:
-          type: object
+          type: string
           nullable: true
     User:
       type: object

--- a/server/main.ts
+++ b/server/main.ts
@@ -2,6 +2,9 @@ import dotenv from 'dotenv'
 dotenv.config()
 
 import Express from 'express'
+import swaggerUi from 'swagger-ui-express'
+import path from 'path'
+import YAML from 'yamljs'
 
 import { redisClient } from './src/config/redis'
 
@@ -9,11 +12,15 @@ import articleRouter from './src/routes/article'
 import authRouter from './src/routes/auth'
 import userRouter from './src/routes/user'
 
+const swaggerYamlPath = path.join(__dirname, './build/swagger.yaml')
+const swaggerDocument = YAML.load(swaggerYamlPath)
+
 redisClient.connect()
 
 const app = Express()
 app.use(Express.json())
 
+app.use('/api-docs', swaggerUi.serve, swaggerUi.setup(swaggerDocument))
 app.use('/api/articles', articleRouter)
 app.use('/api/auth', authRouter)
 app.use('/api/users', userRouter)

--- a/server/package.json
+++ b/server/package.json
@@ -4,17 +4,23 @@
   "description": "",
   "main": "main.ts",
   "scripts": {
+    "predev": "pnpm run api-docs",
     "dev": "nodemon main.ts",
     "test": "jest",
-    "init_db": "npx prisma migrate deploy && npx prisma generate"
+    "init_db": "npx prisma migrate deploy && npx prisma generate",
+    "api-docs": "swagger-cli bundle ./src/swagger/openapi.yaml --outfile build/swagger.yaml --type yaml"
   },
   "dependencies": {
+    "@types/yamljs": "^0.2.34",
     "bcrypt": "^6.0.0",
     "dayjs": "^1.11.13",
     "express": "^4.21.0",
     "jsonwebtoken": "^9.0.2",
     "string-hash": "^1.1.3",
-    "tsconfig": "^7.0.0"
+    "swagger-cli": "^4.0.4",
+    "swagger-ui-express": "^5.0.1",
+    "tsconfig": "^7.0.0",
+    "yamljs": "^0.3.0"
   },
   "devDependencies": {
     "@prisma/client": "^5.20.0",
@@ -25,6 +31,7 @@
     "@types/jsonwebtoken": "^9.0.10",
     "@types/node": "^22.7.4",
     "@types/string-hash": "^1.1.3",
+    "@types/swagger-ui-express": "^4.1.8",
     "dotenv": "^16.4.5",
     "jest-mock-extended": "^4.0.0",
     "node-mocks-http": "^1.17.2",

--- a/server/pnpm-lock.yaml
+++ b/server/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@types/yamljs':
+        specifier: ^0.2.34
+        version: 0.2.34
       bcrypt:
         specifier: ^6.0.0
         version: 6.0.0
@@ -23,9 +26,18 @@ importers:
       string-hash:
         specifier: ^1.1.3
         version: 1.1.3
+      swagger-cli:
+        specifier: ^4.0.4
+        version: 4.0.4(openapi-types@12.1.3)
+      swagger-ui-express:
+        specifier: ^5.0.1
+        version: 5.0.1(express@4.21.2)
       tsconfig:
         specifier: ^7.0.0
         version: 7.0.0
+      yamljs:
+        specifier: ^0.3.0
+        version: 0.3.0
     devDependencies:
       '@prisma/client':
         specifier: ^5.20.0
@@ -51,6 +63,9 @@ importers:
       '@types/string-hash':
         specifier: ^1.1.3
         version: 1.1.3
+      '@types/swagger-ui-express':
+        specifier: ^4.1.8
+        version: 4.1.8
       dotenv:
         specifier: ^16.4.5
         version: 16.6.1
@@ -90,6 +105,27 @@ packages:
   '@ampproject/remapping@2.3.0':
     resolution: {integrity: sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==}
     engines: {node: '>=6.0.0'}
+
+  '@apidevtools/json-schema-ref-parser@9.1.2':
+    resolution: {integrity: sha512-r1w81DpR+KyRWd3f+rk6TNqMgedmAxZP5v5KWlXQWlgMUUtyEJch0DKEci1SorPMiSeM8XPl7MZ3miJ60JIpQg==}
+
+  '@apidevtools/openapi-schemas@2.1.0':
+    resolution: {integrity: sha512-Zc1AlqrJlX3SlpupFGpiLi2EbteyP7fXmUOGup6/DnkRgjP9bgMM/ag+n91rsv0U1Gpz0H3VILA/o3bW7Ua6BQ==}
+    engines: {node: '>=10'}
+
+  '@apidevtools/swagger-cli@4.0.4':
+    resolution: {integrity: sha512-hdDT3B6GLVovCsRZYDi3+wMcB1HfetTU20l2DC8zD3iFRNMC6QNAZG5fo/6PYeHWBEv7ri4MvnlKodhNB0nt7g==}
+    engines: {node: '>=10'}
+    deprecated: This package has been abandoned. Please switch to using the actively maintained @redocly/cli
+    hasBin: true
+
+  '@apidevtools/swagger-methods@3.0.2':
+    resolution: {integrity: sha512-QAkD5kK2b1WfjDS/UQn/qQkbwF31uqRjPTrsCs5ZG9BQGAkjwvqGFjjPqAuzac/IYzpPtRzjCP1WrTuAIjMrXg==}
+
+  '@apidevtools/swagger-parser@10.0.3':
+    resolution: {integrity: sha512-sNiLY51vZOmSPFZA5TF35KZ2HbgYklQnTSDnkghamzLb3EkNtcQnrBQEj5AOCxHpTtXpqMCRM1CrmV2rG6nw4g==}
+    peerDependencies:
+      openapi-types: '>=7'
 
   '@babel/code-frame@7.27.1':
     resolution: {integrity: sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==}
@@ -379,6 +415,9 @@ packages:
   '@jridgewell/trace-mapping@0.3.9':
     resolution: {integrity: sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==}
 
+  '@jsdevtools/ono@7.1.3':
+    resolution: {integrity: sha512-4JQNk+3mVzK3xh2rqd6RB4J46qUR19azEHBneZyTZM+c456qOrbbM/5xcR8huNCCcbVt7+UmizG6GuUvPvKUYg==}
+
   '@napi-rs/wasm-runtime@0.2.11':
     resolution: {integrity: sha512-9DPkXtvHydrcOsopiYpUgPHpmj0HWZKMUnL2dZqpvC42lsratuBG06V5ipyno0fUek5VlFsNQ+AcFATSrJXgMA==}
 
@@ -441,6 +480,9 @@ packages:
     engines: {node: '>= 18'}
     peerDependencies:
       '@redis/client': ^5.5.6
+
+  '@scarf/scarf@1.4.0':
+    resolution: {integrity: sha512-xxeapPiUXdZAE3che6f3xogoJPeZgig6omHEy1rIY5WVsB3H2BHNnZH+gHG6x91SCWyQCzWGsuL2Hh3ClO5/qQ==}
 
   '@sinclair/typebox@0.34.37':
     resolution: {integrity: sha512-2TRuQVgQYfy+EzHRTIvkhv2ADEouJ2xNS/Vq+W5EuuewBdOrvATvljZTxHWZSTYr2sTjTHpGvucaGAt67S2akw==}
@@ -511,6 +553,9 @@ packages:
   '@types/jest@30.0.0':
     resolution: {integrity: sha512-XTYugzhuwqWjws0CVz8QpM36+T+Dz5mTEBKhNs/esGLnCIlGdRy+Dq78NRjd7ls7r8BC8ZRMOrKlkO1hU0JOwA==}
 
+  '@types/json-schema@7.0.15':
+    resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
+
   '@types/jsonwebtoken@9.0.10':
     resolution: {integrity: sha512-asx5hIG9Qmf/1oStypjanR7iKTv0gXQ1Ov/jfrX6kS/EO0OFni8orbmGCn0672NHR3kXHwpAwR+B368ZGN/2rA==}
 
@@ -546,6 +591,12 @@ packages:
 
   '@types/strip-json-comments@0.0.30':
     resolution: {integrity: sha512-7NQmHra/JILCd1QqpSzl8+mJRc8ZHz3uDm8YV1Ks9IhK0epEiTw8aIErbvH9PI+6XbqhyIQy3462nEsn7UVzjQ==}
+
+  '@types/swagger-ui-express@4.1.8':
+    resolution: {integrity: sha512-AhZV8/EIreHFmBV5wAs0gzJUNq9JbbSXgJLQubCC0jtIo6prnI9MIRRxnU4MZX9RB9yXxF1V4R7jtLl/Wcj31g==}
+
+  '@types/yamljs@0.2.34':
+    resolution: {integrity: sha512-gJvfRlv9ErxdOv7ux7UsJVePtX54NAvQyd8ncoiFqK8G5aeHIfQfGH2fbruvjAQ9657HwAaO54waS+Dsk2QTUQ==}
 
   '@types/yargs-parser@21.0.3':
     resolution: {integrity: sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==}
@@ -698,6 +749,9 @@ packages:
   argparse@1.0.10:
     resolution: {integrity: sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==}
 
+  argparse@2.0.1:
+    resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
+
   array-flatten@1.1.1:
     resolution: {integrity: sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==}
 
@@ -784,6 +838,9 @@ packages:
     resolution: {integrity: sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==}
     engines: {node: '>= 0.4'}
 
+  call-me-maybe@1.0.2:
+    resolution: {integrity: sha512-HpX65o1Hnr9HH25ojC1YGs7HCQLq0GCOibSaWER0eNpgJ/Z1MZv2mTc7+xh6WOPxbRVcmgbv4hGU+uSQ/2xFZQ==}
+
   callsites@3.1.0:
     resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
     engines: {node: '>=6'}
@@ -818,6 +875,9 @@ packages:
   cjs-module-lexer@2.1.0:
     resolution: {integrity: sha512-UX0OwmYRYQQetfrLEZeewIFFI+wSTofC+pMBLNuH3RUuu/xzG1oz84UCEDOSoQlN3fZ4+AzmV50ZYvGqkMh9yA==}
 
+  cliui@6.0.0:
+    resolution: {integrity: sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==}
+
   cliui@8.0.1:
     resolution: {integrity: sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==}
     engines: {node: '>=12'}
@@ -839,6 +899,10 @@ packages:
 
   color-name@1.1.4:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
+
+  commander@9.5.0:
+    resolution: {integrity: sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==}
+    engines: {node: ^12.20.0 || >=14}
 
   concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
@@ -890,6 +954,10 @@ packages:
     peerDependenciesMeta:
       supports-color:
         optional: true
+
+  decamelize@1.2.0:
+    resolution: {integrity: sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==}
+    engines: {node: '>=0.10.0'}
 
   dedent@1.6.0:
     resolution: {integrity: sha512-F1Z+5UCFpmQUzJa11agbyPVMbpgT/qA3/SKyJ1jyBgm7dUcUEa8v9JwDkerSQXfakBwFljIxhOJqGkjUwZ9FSA==}
@@ -1365,6 +1433,10 @@ packages:
     resolution: {integrity: sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==}
     hasBin: true
 
+  js-yaml@4.1.0:
+    resolution: {integrity: sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==}
+    hasBin: true
+
   jsesc@3.1.0:
     resolution: {integrity: sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==}
     engines: {node: '>=6'}
@@ -1399,11 +1471,19 @@ packages:
     resolution: {integrity: sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==}
     engines: {node: '>=8'}
 
+  lodash.get@4.4.2:
+    resolution: {integrity: sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==}
+    deprecated: This package is deprecated. Use the optional chaining (?.) operator instead.
+
   lodash.includes@4.3.0:
     resolution: {integrity: sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==}
 
   lodash.isboolean@3.0.3:
     resolution: {integrity: sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==}
+
+  lodash.isequal@4.5.0:
+    resolution: {integrity: sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==}
+    deprecated: This package is deprecated. Use require('node:util').isDeepStrictEqual instead.
 
   lodash.isinteger@4.0.4:
     resolution: {integrity: sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==}
@@ -1574,6 +1654,9 @@ packages:
     resolution: {integrity: sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==}
     engines: {node: '>=6'}
 
+  openapi-types@12.1.3:
+    resolution: {integrity: sha512-N4YtSYJqghVu4iek2ZUvcN/0aqH1kRDuNqzcycDxhOUpg7GdvLa2F3DgS6yBNhInhv2r/6I0Flkn7CqL8+nIcw==}
+
   p-limit@2.3.0:
     resolution: {integrity: sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==}
     engines: {node: '>=6'}
@@ -1694,6 +1777,9 @@ packages:
     resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
     engines: {node: '>=0.10.0'}
 
+  require-main-filename@2.0.0:
+    resolution: {integrity: sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==}
+
   resolve-cwd@3.0.0:
     resolution: {integrity: sha512-OrZaX2Mb+rJCpH/6CpSqt9xFVpN++x01XnN2ie9g6P5/3xelLAkXWVADpdz1IHD/KFfEXyE6V0U01OQ3UO2rEg==}
     engines: {node: '>=8'}
@@ -1724,6 +1810,9 @@ packages:
   serve-static@1.16.2:
     resolution: {integrity: sha512-VqpjJZKadQB/PEbEwvFdO43Ax5dFBZ2UECszz8bQ7pi7wt//PWe1P6MN7eCnjsatYtBT6EuiClbjSWP2WrIoTw==}
     engines: {node: '>= 0.8.0'}
+
+  set-blocking@2.0.0:
+    resolution: {integrity: sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==}
 
   setprototypeof@1.2.0:
     resolution: {integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==}
@@ -1843,6 +1932,20 @@ packages:
   supports-color@8.1.1:
     resolution: {integrity: sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==}
     engines: {node: '>=10'}
+
+  swagger-cli@4.0.4:
+    resolution: {integrity: sha512-Cp8YYuLny3RJFQ4CvOBTaqmOOgYsem52dPx1xM5S4EUWFblIh2Q8atppMZvXKUr1e9xH5RwipYpmdUzdPcxWcA==}
+    engines: {node: '>=10'}
+    hasBin: true
+
+  swagger-ui-dist@5.27.0:
+    resolution: {integrity: sha512-tS6LRyBhY6yAqxrfsA9IYpGWPUJOri6sclySa7TdC7XQfGLvTwDY531KLgfQwHEtQsn+sT4JlUspbeQDBVGWig==}
+
+  swagger-ui-express@5.0.1:
+    resolution: {integrity: sha512-SrNU3RiBGTLLmFU8GIJdOdanJTl4TOmT27tt3bWWHppqYmAZ6IDuEuBvMU6nZq0zLEe6b/1rACXCgLZqO6ZfrA==}
+    engines: {node: '>= v0.10.32'}
+    peerDependencies:
+      express: '>=4.0.0 || >=5.0.0-beta'
 
   synckit@0.11.8:
     resolution: {integrity: sha512-+XZ+r1XGIJGeQk3VvXhT6xx/VpbHsRzsTkGgF6E5RX9TTXD0118l87puaEBZ566FhqblC6U0d4XnubznJDm30A==}
@@ -1976,6 +2079,10 @@ packages:
     resolution: {integrity: sha512-kiGUalWN+rgBJ/1OHZsBtU4rXZOfj/7rKQxULKlIzwzQSvMJUUNgPwJEEh7gU6xEVxC0ahoOBvN2YI8GH6FNgA==}
     engines: {node: '>=10.12.0'}
 
+  validator@13.15.15:
+    resolution: {integrity: sha512-BgWVbCI72aIQy937xbawcs+hrVaN/CZ2UwutgaJ36hGqRrLNM+f5LUT/YPRbo8IV/ASeFzXszezV+y2+rq3l8A==}
+    engines: {node: '>= 0.10'}
+
   vary@1.1.2:
     resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
     engines: {node: '>= 0.8'}
@@ -1989,10 +2096,17 @@ packages:
   whatwg-url@5.0.0:
     resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
 
+  which-module@2.0.1:
+    resolution: {integrity: sha512-iBdZ57RDvnOR9AGBhML2vFZf7h8vmBjhoaZqODJBFWHVtKkDmKuHai3cx5PgVMrX5YDNp27AofYbAwctSS+vhQ==}
+
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
     engines: {node: '>= 8'}
     hasBin: true
+
+  wrap-ansi@6.2.0:
+    resolution: {integrity: sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==}
+    engines: {node: '>=8'}
 
   wrap-ansi@7.0.0:
     resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
@@ -2009,6 +2123,9 @@ packages:
     resolution: {integrity: sha512-+QU2zd6OTD8XWIJCbffaiQeH9U73qIqafo1x6V1snCWYGJf6cVE0cDR4D8xRzcEnfI21IFrUPzPGtcPf8AC+Rw==}
     engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
 
+  y18n@4.0.3:
+    resolution: {integrity: sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==}
+
   y18n@5.0.8:
     resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
     engines: {node: '>=10'}
@@ -2016,9 +2133,21 @@ packages:
   yallist@3.1.1:
     resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
 
+  yamljs@0.3.0:
+    resolution: {integrity: sha512-C/FsVVhht4iPQYXOInoxUM/1ELSf9EsgKH34FofQOp6hwCPrW4vG4w5++TED3xRUo8gD7l0P1J1dLlDYzODsTQ==}
+    hasBin: true
+
+  yargs-parser@18.1.3:
+    resolution: {integrity: sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==}
+    engines: {node: '>=6'}
+
   yargs-parser@21.1.1:
     resolution: {integrity: sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==}
     engines: {node: '>=12'}
+
+  yargs@15.4.1:
+    resolution: {integrity: sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==}
+    engines: {node: '>=8'}
 
   yargs@17.7.2:
     resolution: {integrity: sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==}
@@ -2032,12 +2161,47 @@ packages:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
 
+  z-schema@5.0.5:
+    resolution: {integrity: sha512-D7eujBWkLa3p2sIpJA0d1pr7es+a7m0vFAnZLlCEKq/Ij2k0MLi9Br2UPxoxdYystm5K1yeBGzub0FlYUEWj2Q==}
+    engines: {node: '>=8.0.0'}
+    hasBin: true
+
 snapshots:
 
   '@ampproject/remapping@2.3.0':
     dependencies:
       '@jridgewell/gen-mapping': 0.3.12
       '@jridgewell/trace-mapping': 0.3.29
+
+  '@apidevtools/json-schema-ref-parser@9.1.2':
+    dependencies:
+      '@jsdevtools/ono': 7.1.3
+      '@types/json-schema': 7.0.15
+      call-me-maybe: 1.0.2
+      js-yaml: 4.1.0
+
+  '@apidevtools/openapi-schemas@2.1.0': {}
+
+  '@apidevtools/swagger-cli@4.0.4(openapi-types@12.1.3)':
+    dependencies:
+      '@apidevtools/swagger-parser': 10.0.3(openapi-types@12.1.3)
+      chalk: 4.1.2
+      js-yaml: 3.14.1
+      yargs: 15.4.1
+    transitivePeerDependencies:
+      - openapi-types
+
+  '@apidevtools/swagger-methods@3.0.2': {}
+
+  '@apidevtools/swagger-parser@10.0.3(openapi-types@12.1.3)':
+    dependencies:
+      '@apidevtools/json-schema-ref-parser': 9.1.2
+      '@apidevtools/openapi-schemas': 2.1.0
+      '@apidevtools/swagger-methods': 3.0.2
+      '@jsdevtools/ono': 7.1.3
+      call-me-maybe: 1.0.2
+      openapi-types: 12.1.3
+      z-schema: 5.0.5
 
   '@babel/code-frame@7.27.1':
     dependencies:
@@ -2465,6 +2629,8 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.4
 
+  '@jsdevtools/ono@7.1.3': {}
+
   '@napi-rs/wasm-runtime@0.2.11':
     dependencies:
       '@emnapi/core': 1.4.3
@@ -2521,6 +2687,8 @@ snapshots:
   '@redis/time-series@5.5.6(@redis/client@5.5.6)':
     dependencies:
       '@redis/client': 5.5.6
+
+  '@scarf/scarf@1.4.0': {}
 
   '@sinclair/typebox@0.34.37': {}
 
@@ -2612,6 +2780,8 @@ snapshots:
       expect: 30.0.4
       pretty-format: 30.0.2
 
+  '@types/json-schema@7.0.15': {}
+
   '@types/jsonwebtoken@9.0.10':
     dependencies:
       '@types/ms': 2.1.0
@@ -2647,6 +2817,13 @@ snapshots:
   '@types/strip-bom@3.0.0': {}
 
   '@types/strip-json-comments@0.0.30': {}
+
+  '@types/swagger-ui-express@4.1.8':
+    dependencies:
+      '@types/express': 4.17.23
+      '@types/serve-static': 1.15.8
+
+  '@types/yamljs@0.2.34': {}
 
   '@types/yargs-parser@21.0.3': {}
 
@@ -2752,6 +2929,8 @@ snapshots:
   argparse@1.0.10:
     dependencies:
       sprintf-js: 1.0.3
+
+  argparse@2.0.1: {}
 
   array-flatten@1.1.1: {}
 
@@ -2881,6 +3060,8 @@ snapshots:
       call-bind-apply-helpers: 1.0.2
       get-intrinsic: 1.3.0
 
+  call-me-maybe@1.0.2: {}
+
   callsites@3.1.0: {}
 
   camelcase@5.3.1: {}
@@ -2912,6 +3093,12 @@ snapshots:
 
   cjs-module-lexer@2.1.0: {}
 
+  cliui@6.0.0:
+    dependencies:
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+      wrap-ansi: 6.2.0
+
   cliui@8.0.1:
     dependencies:
       string-width: 4.2.3
@@ -2929,6 +3116,9 @@ snapshots:
       color-name: 1.1.4
 
   color-name@1.1.4: {}
+
+  commander@9.5.0:
+    optional: true
 
   concat-map@0.0.1: {}
 
@@ -2965,6 +3155,8 @@ snapshots:
       ms: 2.1.3
     optionalDependencies:
       supports-color: 5.5.0
+
+  decamelize@1.2.0: {}
 
   dedent@1.6.0: {}
 
@@ -3634,6 +3826,10 @@ snapshots:
       argparse: 1.0.10
       esprima: 4.0.1
 
+  js-yaml@4.1.0:
+    dependencies:
+      argparse: 2.0.1
+
   jsesc@3.1.0: {}
 
   json-parse-even-better-errors@2.3.1: {}
@@ -3672,9 +3868,13 @@ snapshots:
     dependencies:
       p-locate: 4.1.0
 
+  lodash.get@4.4.2: {}
+
   lodash.includes@4.3.0: {}
 
   lodash.isboolean@3.0.3: {}
+
+  lodash.isequal@4.5.0: {}
 
   lodash.isinteger@4.0.4: {}
 
@@ -3814,6 +4014,8 @@ snapshots:
     dependencies:
       mimic-fn: 2.1.0
 
+  openapi-types@12.1.3: {}
+
   p-limit@2.3.0:
     dependencies:
       p-try: 2.2.0
@@ -3920,6 +4122,8 @@ snapshots:
 
   require-directory@2.1.1: {}
 
+  require-main-filename@2.0.0: {}
+
   resolve-cwd@3.0.0:
     dependencies:
       resolve-from: 5.0.0
@@ -3960,6 +4164,8 @@ snapshots:
       send: 0.19.0
     transitivePeerDependencies:
       - supports-color
+
+  set-blocking@2.0.0: {}
 
   setprototypeof@1.2.0: {}
 
@@ -4078,6 +4284,21 @@ snapshots:
   supports-color@8.1.1:
     dependencies:
       has-flag: 4.0.0
+
+  swagger-cli@4.0.4(openapi-types@12.1.3):
+    dependencies:
+      '@apidevtools/swagger-cli': 4.0.4(openapi-types@12.1.3)
+    transitivePeerDependencies:
+      - openapi-types
+
+  swagger-ui-dist@5.27.0:
+    dependencies:
+      '@scarf/scarf': 1.4.0
+
+  swagger-ui-express@5.0.1(express@4.21.2):
+    dependencies:
+      express: 4.21.2
+      swagger-ui-dist: 5.27.0
 
   synckit@0.11.8:
     dependencies:
@@ -4212,6 +4433,8 @@ snapshots:
       '@types/istanbul-lib-coverage': 2.0.6
       convert-source-map: 2.0.0
 
+  validator@13.15.15: {}
+
   vary@1.1.2: {}
 
   walker@1.0.8:
@@ -4225,9 +4448,17 @@ snapshots:
       tr46: 0.0.3
       webidl-conversions: 3.0.1
 
+  which-module@2.0.1: {}
+
   which@2.0.2:
     dependencies:
       isexe: 2.0.0
+
+  wrap-ansi@6.2.0:
+    dependencies:
+      ansi-styles: 4.3.0
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
 
   wrap-ansi@7.0.0:
     dependencies:
@@ -4248,11 +4479,37 @@ snapshots:
       imurmurhash: 0.1.4
       signal-exit: 4.1.0
 
+  y18n@4.0.3: {}
+
   y18n@5.0.8: {}
 
   yallist@3.1.1: {}
 
+  yamljs@0.3.0:
+    dependencies:
+      argparse: 1.0.10
+      glob: 7.2.3
+
+  yargs-parser@18.1.3:
+    dependencies:
+      camelcase: 5.3.1
+      decamelize: 1.2.0
+
   yargs-parser@21.1.1: {}
+
+  yargs@15.4.1:
+    dependencies:
+      cliui: 6.0.0
+      decamelize: 1.2.0
+      find-up: 4.1.0
+      get-caller-file: 2.0.5
+      require-directory: 2.1.1
+      require-main-filename: 2.0.0
+      set-blocking: 2.0.0
+      string-width: 4.2.3
+      which-module: 2.0.1
+      y18n: 4.0.3
+      yargs-parser: 18.1.3
 
   yargs@17.7.2:
     dependencies:
@@ -4267,3 +4524,11 @@ snapshots:
   yn@3.1.1: {}
 
   yocto-queue@0.1.0: {}
+
+  z-schema@5.0.5:
+    dependencies:
+      lodash.get: 4.4.2
+      lodash.isequal: 4.5.0
+      validator: 13.15.15
+    optionalDependencies:
+      commander: 9.5.0

--- a/server/src/swagger/openapi.yaml
+++ b/server/src/swagger/openapi.yaml
@@ -24,19 +24,40 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/SuccessMessageResponse'
+                $ref: '#/components/schemas/SuccessResponse'
+              examples:
+                success:
+                  summary: 인증코드 전송 성공
+                  value:
+                    success: true
+                    data: null
+                    message: Verification code sent successfully
+
         '400':
           description: 잘못된 요청 (phoneNumber 미입력)
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                invalidPhoneNumber:
+                  summary: 잘못된 휴대폰 번호
+                  value:
+                    success: false
+                    message: Phone number is required
+
         '500':
           description: 서버 오류
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                serverError:
+                  summary: 서버 오류
+                  value:
+                    success: false
+                    message: Internal server error
 
   /auth/phone/verify:
     post:
@@ -57,18 +78,42 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/PhoneVerifySuccessResponse'
+
         '400':
           description: 잘못된 요청 (파라미터 누락, 인증코드 불일치 등)
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                missingParameters:
+                  summary: 파라미터 누락
+                  value:
+                    success: false
+                    message: Phone number and code are required
+                invalidCode:
+                  summary: 잘못된 인증 코드
+                  value:
+                    success: false
+                    message: Invalid verification code
+                codeExpired:
+                  summary: 인증 코드 만료
+                  value:
+                    success: false
+                    message: Verification code has expired
+
         '500':
           description: 서버 오류
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                serverError:
+                  summary: 서버 오류
+                  value:
+                    success: false
+                    message: Internal server error
 
   /auth/refresh:
     post:
@@ -87,30 +132,63 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/TokenResponse'
+
         '400':
           description: 잘못된 요청 (refreshToken 미입력)
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                missingRefreshToken:
+                  summary: 리프레시 토큰 누락
+                  value:
+                    success: false
+                    message: Refresh token is required
+
         '401':
-          description: 리프레시 토큰이 유효하지 않음
+          description: 리프레시 토큰이 유효하지 않거나 찾을 수 없음
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                invalidRefreshToken:
+                  summary: 유효하지 않은 리프레시 토큰
+                  value:
+                    success: false
+                    message: Invalid refresh token
+                refreshTokenNotFound:
+                  summary: 리프레시 토큰을 찾을 수 없음
+                  value:
+                    success: false
+                    message: Refresh token not found for the user
+
         '404':
           description: 사용자 정보 없음
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                userNotFound:
+                  summary: 사용자 정보 없음
+                  value:
+                    success: false
+                    message: User not found
+
         '500':
           description: 서버 오류
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                serverError:
+                  summary: 서버 오류
+                  value:
+                    success: false
+                    message: Internal server error
 
   /articles:
     get:
@@ -135,12 +213,19 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ArticleCursorPaginationResponse'
+
         '500':
           description: 서버 오류
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                serverError:
+                  summary: 서버 오류
+                  value:
+                    success: false
+                    message: Internal server error
 
   /articles/{id}:
     get:
@@ -160,18 +245,32 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ArticleResponse'
+
         '404':
           description: 기사 없음
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                articleNotFound:
+                  summary: 기사를 찾을 수 없음
+                  value:
+                    success: false
+                    message: Article not found
+
         '500':
           description: 서버 오류
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                serverError:
+                  summary: 서버 오류
+                  value:
+                    success: false
+                    message: Internal server error
 
 components:
   schemas:
@@ -210,20 +309,6 @@ components:
           description: 리프레시 토큰
           example: your_refresh_token_here
 
-    SuccessMessageResponse:
-      type: object
-      properties:
-        success:
-          type: boolean
-          example: true
-        data:
-          type: 'null'
-          nullable: true
-          example: null
-        message:
-          type: string
-          example: Verification code sent successfully
-
     PhoneVerifySuccessResponse:
       type: object
       properties:
@@ -253,6 +338,20 @@ components:
           type: string
           example: Access token refreshed successfully
 
+    SuccessResponse:
+      type: object
+      properties:
+        success:
+          type: boolean
+          example: true
+        data:
+          type: 'null'
+          nullable: true
+          example: null
+        message:
+          type: string
+          example: Verification code sent successfully
+
     ErrorResponse:
       type: object
       properties:
@@ -261,13 +360,12 @@ components:
           example: false
         message:
           type: string
-          example: Invalid verification code
+          example: Internal server error
         code:
           type: string
           nullable: true
-          example: BAD_REQUEST
         details:
-          type: object
+          type: string
           nullable: true
 
     User:

--- a/server/src/swagger/openapi.yaml
+++ b/server/src/swagger/openapi.yaml
@@ -1,0 +1,383 @@
+openapi: 3.0.3
+info:
+  title: Somesup API Documentation
+  version: 1.0.0
+  description: |
+    썸즈업 API 문서입니다.
+servers:
+  - url: /api
+
+paths:
+  /auth/phone/request:
+    post:
+      summary: 휴대폰 번호 인증 요청
+      description: 사용자가 입력한 'phoneNumber'로 인증코드를 전송합니다.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PhoneRequest'
+      responses:
+        '200':
+          description: 인증코드 전송 성공
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SuccessMessageResponse'
+        '400':
+          description: 잘못된 요청 (phoneNumber 미입력)
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: 서버 오류
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+  /auth/phone/verify:
+    post:
+      summary: 휴대폰 인증 코드 검증 및 회원 가입/로그인
+      description: |
+        인증코드가 맞으면 사용자 정보 및 JWT 토큰 발급. 신규 사용자는 회원가입 후 발급됨.
+        새로운 사용자는 랜덤 닉네임이 생성되어 회원가입되고, 이후 사용자는 닉네임을 변경할 수 있음.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PhoneVerifyRequest'
+      responses:
+        '200':
+          description: 인증 성공, 사용자 정보 및 액세스/리프레시 토큰 반환
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PhoneVerifySuccessResponse'
+        '400':
+          description: 잘못된 요청 (파라미터 누락, 인증코드 불일치 등)
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: 서버 오류
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+  /auth/refresh:
+    post:
+      summary: 액세스 토큰 갱신
+      description: 유효한 리프레시 토큰을 이용해 새 액세스/리프레시 토큰을 발급합니다.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RefreshTokenRequest'
+      responses:
+        '200':
+          description: 토큰 갱신 성공
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TokenResponse'
+        '400':
+          description: 잘못된 요청 (refreshToken 미입력)
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '401':
+          description: 리프레시 토큰이 유효하지 않음
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '404':
+          description: 사용자 정보 없음
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: 서버 오류
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+  /articles:
+    get:
+      summary: 기사 목록 조회 (Cursor 기반 페이지네이션)
+      description: limit 및 cursor 쿼리 파라미터를 이용해 기사를 조회합니다.
+      parameters:
+        - in: query
+          name: limit
+          schema:
+            type: integer
+            default: 10
+          description: 한 번에 조회할 기사 개수 (기본값 10)
+        - in: query
+          name: cursor
+          schema:
+            type: string
+          description: 커서 값 (이후 페이지 조회 시 사용)
+      responses:
+        '200':
+          description: 기사 목록 조회 성공
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ArticleCursorPaginationResponse'
+        '500':
+          description: 서버 오류
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+  /articles/{id}:
+    get:
+      summary: 특정 기사 조회
+      description: ID로 특정 기사를 조회합니다.
+      parameters:
+        - in: path
+          name: id
+          schema:
+            type: integer
+          required: true
+          description: 기사 ID
+      responses:
+        '200':
+          description: 기사 조회 성공
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ArticleResponse'
+        '404':
+          description: 기사 없음
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: 서버 오류
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+components:
+  schemas:
+    PhoneRequest:
+      type: object
+      required:
+        - phoneNumber
+      properties:
+        phoneNumber:
+          type: string
+          description: 휴대폰 번호
+          example: '01012345678'
+
+    PhoneVerifyRequest:
+      type: object
+      required:
+        - phoneNumber
+        - code
+      properties:
+        phoneNumber:
+          type: string
+          description: 휴대폰 번호
+          example: '01012345678'
+        code:
+          type: string
+          description: 인증 코드
+          example: '123456'
+
+    RefreshTokenRequest:
+      type: object
+      required:
+        - refreshToken
+      properties:
+        refreshToken:
+          type: string
+          description: 리프레시 토큰
+          example: your_refresh_token_here
+
+    SuccessMessageResponse:
+      type: object
+      properties:
+        success:
+          type: boolean
+          example: true
+        data:
+          type: 'null'
+          nullable: true
+          example: null
+        message:
+          type: string
+          example: Verification code sent successfully
+
+    PhoneVerifySuccessResponse:
+      type: object
+      properties:
+        success:
+          type: boolean
+          example: true
+        data:
+          type: object
+          properties:
+            user:
+              $ref: '#/components/schemas/User'
+            tokens:
+              $ref: '#/components/schemas/Tokens'
+        message:
+          type: string
+          example: Phone verification successful
+
+    TokenResponse:
+      type: object
+      properties:
+        success:
+          type: boolean
+          example: true
+        data:
+          $ref: '#/components/schemas/Tokens'
+        message:
+          type: string
+          example: Access token refreshed successfully
+
+    ErrorResponse:
+      type: object
+      properties:
+        success:
+          type: boolean
+          example: false
+        message:
+          type: string
+          example: Invalid verification code
+        code:
+          type: string
+          nullable: true
+          example: BAD_REQUEST
+        details:
+          type: object
+          nullable: true
+
+    User:
+      type: object
+      properties:
+        id:
+          type: integer
+          example: 1
+        phone:
+          type: string
+          example: 01012345678
+        nickname:
+          type: string
+          example: '슈퍼파워알파'
+
+    Tokens:
+      type: object
+      properties:
+        accessToken:
+          type: string
+          example: <access_token>
+        refreshToken:
+          type: string
+          example: <refresh_token>
+
+    Article:
+      type: object
+      properties:
+        id:
+          type: integer
+          example: 1
+        provider_id:
+          type: integer
+          example: 2
+        processed_id:
+          type: integer
+          nullable: true
+          example: 10
+        title:
+          type: string
+          example: 'Example Article Title'
+        content:
+          type: string
+          example: '기사 본문 내용입니다.'
+        language:
+          type: string
+          example: 'ko'
+        region:
+          type: string
+          nullable: true
+          example: 'Seoul'
+        section:
+          type: string
+          nullable: true
+          example: 'politics'
+        thumbnail_url:
+          type: string
+          example: 'https://example.com/image.jpg'
+        news_url:
+          type: string
+          example: 'https://news.example.com/article/1'
+        is_processed:
+          type: boolean
+          example: false
+        created_at:
+          type: string
+          format: date-time
+          example: '2023-09-21T12:00:00.000Z'
+
+    ArticleCursorPaginationResponse:
+      type: object
+      properties:
+        success:
+          type: boolean
+          example: true
+        data:
+          type: array
+          items:
+            $ref: '#/components/schemas/Article'
+        pagination:
+          type: object
+          properties:
+            type:
+              type: string
+              enum: [cursor]
+              example: cursor
+            hasNext:
+              type: boolean
+              example: true
+            hasPrev:
+              type: boolean
+              nullable: true
+              example: false
+            nextCursor:
+              type: string
+              nullable: true
+              example: eyJjcmVhdGVkQXQiOiIyMDIzLTA5LTIxVDEyOjAwOjAwLjAwMFoiLCJpZCI6Mn0=
+            prevCursor:
+              type: string
+              nullable: true
+              example: null
+
+    ArticleResponse:
+      type: object
+      properties:
+        success:
+          type: boolean
+          example: true
+        data:
+          $ref: '#/components/schemas/Article'
+        message:
+          type: string
+          example: Article retrieved successfully


### PR DESCRIPTION
# Changelog
- `swagger-cli`, `swagger-ui-express` 를 설치하여 Swagger API Documentation을 사용할 수 있도록 구성하였습니다.
- `pnpm dev`를 하면 swagger api docs를 업데이트하고 실행되도록 설정하였습니다.
- Article, Auth 에 대한 Swagger 문서를 작성하였습니다.

# Testing
<img width="1395" height="1674" alt="image" src="https://github.com/user-attachments/assets/d816f75a-4fa5-49fb-b18b-eee7bca752d0" />

# Ops Impact
N/A

# Version Compatibility
N/A