### PR TITLE
[Server] 사용자 정보 PATCH API 구현

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -20,7 +20,8 @@
     "swagger-cli": "^4.0.4",
     "swagger-ui-express": "^5.0.1",
     "tsconfig": "^7.0.0",
-    "yamljs": "^0.3.0"
+    "yamljs": "^0.3.0",
+    "zod": "^4.0.10"
   },
   "devDependencies": {
     "@prisma/client": "^5.20.0",

--- a/server/pnpm-lock.yaml
+++ b/server/pnpm-lock.yaml
@@ -38,6 +38,9 @@ importers:
       yamljs:
         specifier: ^0.3.0
         version: 0.3.0
+      zod:
+        specifier: ^4.0.10
+        version: 4.0.10
     devDependencies:
       '@prisma/client':
         specifier: ^5.20.0
@@ -2165,6 +2168,9 @@ packages:
     resolution: {integrity: sha512-D7eujBWkLa3p2sIpJA0d1pr7es+a7m0vFAnZLlCEKq/Ij2k0MLi9Br2UPxoxdYystm5K1yeBGzub0FlYUEWj2Q==}
     engines: {node: '>=8.0.0'}
     hasBin: true
+
+  zod@4.0.10:
+    resolution: {integrity: sha512-3vB+UU3/VmLL2lvwcY/4RV2i9z/YU0DTV/tDuYjrwmx5WeJ7hwy+rGEEx8glHp6Yxw7ibRbKSaIFBgReRPe5KA==}
 
 snapshots:
 
@@ -4532,3 +4538,5 @@ snapshots:
       validator: 13.15.15
     optionalDependencies:
       commander: 9.5.0
+
+  zod@4.0.10: {}

--- a/server/src/controllers/__tests__/articleController.test.ts
+++ b/server/src/controllers/__tests__/articleController.test.ts
@@ -1,5 +1,5 @@
 import { getArticles, getArticleById } from '../articleController'
-import { articleService } from '../../services/articleService'
+import { ArticleNotFoundError, articleService } from '../../services/articleService'
 import { successWithCursor, success, errors } from '../../utils/response'
 
 jest.mock('../../services/articleService')
@@ -94,6 +94,16 @@ describe('articleController', () => {
 
       expect(articleService.getArticleById).toHaveBeenCalledWith(3)
       expect(mockSuccess).toHaveBeenCalled()
+    })
+
+    it('should respond with not found if article does not exist', async () => {
+      req.params.id = '100'
+      ;(articleService.getArticleById as jest.Mock).mockRejectedValue(new ArticleNotFoundError('Article not found'))
+
+      await getArticleById(req, res)
+
+      expect(mockSuccess).not.toHaveBeenCalled()
+      expect(errors.notFound).toHaveBeenCalledWith(res, 'Article not found')
     })
 
     it('should respond with internal error on service exception', async () => {

--- a/server/src/controllers/userController.ts
+++ b/server/src/controllers/userController.ts
@@ -1,3 +1,4 @@
+import { z } from 'zod'
 import { Response } from 'express'
 import { errors, success } from '../utils/response'
 import { AuthenticatedRequest } from '../middlewares/authenticateJWT'
@@ -40,4 +41,49 @@ export const updateNickname = async (req: AuthenticatedRequest, res: Response): 
   } catch (error) {
     return errors.internal(res)
   }
+}
+
+/**
+ * 사용자 정보를 업데이트하는 요청 형태입니다.
+ */
+export type UpdateUserRequest = {
+  nickname?: string
+}
+
+/**
+ * 사용자 정보를 업데이트하는 컨트롤러입니다.
+ * 사용자가 인증된 상태에서 자신의 정보를 변경할 수 있습니다.
+ * @param {AuthenticatedRequest} req - 인증된 사용자 요청 객체. userId와 body에 nickname이 포함되어야 합니다.
+ * @param {Response} res - Express 응답 객체.
+ * @example
+ * // 요청 예시
+ * PATCH /api/user
+ * {
+ * "nickname": "newNickname"
+ * }
+ * @returns {Promise<Response>} 업데이트된 사용자 정보를 포함한 응답 객체
+ */
+export const updateUser = async (req: AuthenticatedRequest, res: Response): Promise<Response> => {
+  const userId = req.userId
+  if (!userId) {
+    return errors.unauthorized(res, 'User ID is required')
+  }
+
+  // NOTE: 악의적으로 인증 여부 등을 수정하는 것을 막기 위해 체크
+  const updateUserSchema = z
+    .object({
+      nickname: z.string().optional(),
+    })
+    .strict()
+
+  const parsed = updateUserSchema.safeParse(req.body)
+  if (!parsed.success) {
+    return errors.badRequest(res, 'Invalid request body, possibly wrong field names')
+  }
+
+  const user = await userService.updateUserInfo(userId, parsed.data)
+
+  return success(res, user, {
+    message: 'User information updated successfully',
+  })
 }

--- a/server/src/routes/user.ts
+++ b/server/src/routes/user.ts
@@ -1,9 +1,12 @@
 import { Router } from 'express'
 import { authenticateJWT } from '../middlewares/authenticateJWT'
-import { updateNickname } from '../controllers/userController'
+import { updateNickname, updateUser } from '../controllers/userController'
 
 const router = Router()
 
-router.put('/me/nickname', authenticateJWT, updateNickname)
+/**
+ * 사용자 닉네임 업데이트
+ */
+router.patch('/', authenticateJWT, updateUser)
 
 export default router

--- a/server/src/services/__tests__/userService.test.ts
+++ b/server/src/services/__tests__/userService.test.ts
@@ -100,4 +100,21 @@ describe('userService', () => {
       expect(result).toEqual(updatedUser)
     })
   })
+
+  describe('updateUserInfo', () => {
+    it('should update user info and return updated user', async () => {
+      const updateData = { nickname: '새로운 닉네임' }
+      const updatedUser = { ...mockUser, nickname: '새로운 닉네임' }
+
+      ;(prismaMock.user.update as jest.Mock).mockResolvedValue(updatedUser)
+
+      const result = await userService.updateUserInfo(1, updateData)
+
+      expect(prismaMock.user.update).toHaveBeenCalledWith({
+        where: { id: 1 },
+        data: updateData,
+      })
+      expect(result).toEqual(updatedUser)
+    })
+  })
 })

--- a/server/src/services/userService.ts
+++ b/server/src/services/userService.ts
@@ -1,5 +1,6 @@
 import { prisma } from '../../prisma/prisma'
 import { User } from '@prisma/client'
+import { UpdateUserRequest } from '../controllers/userController'
 
 /**
  * 사용자 관련 데이터베이스 작업을 처리하는 서비스 객체입니다.
@@ -80,6 +81,22 @@ export const userService = {
     const user = await prisma.user.update({
       where: { id: userId },
       data: { nickname },
+    })
+    return user
+  },
+
+  /**
+   * 사용자의 정보를 업데이트합니다.
+   *
+   * @async
+   * @param {number} userId - 정보를 업데이트할 사용자의 ID
+   * @param {UpdateUserRequest} updateInfo - 업데이트할 사용자 정보
+   * @returns {Promise<User>} 업데이트된 사용자 객체
+   */
+  updateUserInfo: async (userId: number, updateInfo: UpdateUserRequest): Promise<User> => {
+    const user = await prisma.user.update({
+      where: { id: userId },
+      data: updateInfo,
     })
     return user
   },


### PR DESCRIPTION
# Changelog
- 사용자 정보를 수정할 수 있는 PATCH API를 구현하였습니다.
- 현재 수정 가능한 정보는 [ 'nickname' ] 이며, 다른 필드를 포함할 경우 에러가 반환됩니다. (악의적으로 `is_authenticated` 등을 바꾸지 못하게 하기 위함입니다.)

# Testing

<!-- 테스트 방법과 결과를 상세히 기술해주세요. -->
<!-- 단위 테스트, 통합 테스트 결과나 수동 테스트 내용을 포함해주세요. -->
<!-- 스크린샷이나 로그도 첨부하면 좋습니다. -->

# Ops Impact

<!-- 이 변경사항이 운영에 미치는 영향을 설명해주세요. -->
<!-- 서버 재시작이 필요한지, DB 마이그레이션이 있는지, 성능에 영향을 주는지 등 운영팀이 알아야 할 사항을 기재해주세요. -->
<!-- 해당 사항이 없다면 N/A로 기재해주세요. -->

# Version Compatibility

<!-- 이 변경사항이 기존 버전과의 호환성에 영향을 주는지 설명해주세요. -->
<!-- 하위/상위 버전 호환성 이슈가 있는지, 클라이언트/서버 버전 동기화가 필요한지 등을 기재해주세요. -->
<!-- 해당 사항이 없다면 N/A로 기재해주세요. -->
