### PR TITLE
[Server] 사용자 정보 업데이트 API 개선

### DIFF
--- a/server/src/controllers/userController.ts
+++ b/server/src/controllers/userController.ts
@@ -2,7 +2,7 @@ import { z } from 'zod'
 import { Response } from 'express'
 import { errors, success } from '../utils/response'
 import { AuthenticatedRequest } from '../middlewares/authenticateJWT'
-import { userService } from '../services/userService'
+import { UserNotFoundError, userService } from '../services/userService'
 
 /**
  * 사용자의 닉네임을 업데이트하는 컨트롤러입니다.
@@ -64,26 +64,33 @@ export type UpdateUserRequest = {
  * @returns {Promise<Response>} 업데이트된 사용자 정보를 포함한 응답 객체
  */
 export const updateUser = async (req: AuthenticatedRequest, res: Response): Promise<Response> => {
-  const userId = req.userId
-  if (!userId) {
-    return errors.unauthorized(res, 'User ID is required')
-  }
+  try {
+    const userId = req.userId
+    if (!userId) {
+      return errors.unauthorized(res, 'User ID is required')
+    }
 
-  // NOTE: 악의적으로 인증 여부 등을 수정하는 것을 막기 위해 체크
-  const updateUserSchema = z
-    .object({
-      nickname: z.string().optional(),
+    // NOTE: 악의적으로 인증 여부 등을 수정하는 것을 막기 위해 체크
+    const updateUserSchema = z
+      .object({
+        nickname: z.string().optional(),
+      })
+      .strict()
+
+    const parsed = updateUserSchema.safeParse(req.body)
+    if (!parsed.success) {
+      return errors.badRequest(res, 'Invalid request body, possibly due to unsupported fields')
+    }
+
+    const user = await userService.updateUserInfo(userId, parsed.data)
+
+    return success(res, user, {
+      message: 'User information updated successfully',
     })
-    .strict()
-
-  const parsed = updateUserSchema.safeParse(req.body)
-  if (!parsed.success) {
-    return errors.badRequest(res, 'Invalid request body, possibly wrong field names')
+  } catch (error) {
+    if (error instanceof UserNotFoundError) {
+      return errors.notFound(res, 'User not found')
+    }
+    return errors.internal(res)
   }
-
-  const user = await userService.updateUserInfo(userId, parsed.data)
-
-  return success(res, user, {
-    message: 'User information updated successfully',
-  })
 }

--- a/server/src/swagger/openapi.yaml
+++ b/server/src/swagger/openapi.yaml
@@ -288,6 +288,83 @@ paths:
                     success: false
                     message: Internal server error
 
+  /users:
+    patch:
+      summary: 사용자 정보 업데이트
+      description: 사용자의 정보를 업데이트 합니다. 현재는 닉네임만 업데이트 가능합니다.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UpdateUserInfoRequest'
+      responses:
+        '200':
+          description: 사용자 정보 업데이트 성공
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SuccessResponse'
+              examples:
+                success:
+                  summary: 사용자 정보 업데이트 성공
+                  value:
+                    success: true
+                    data: '#/components/schemas/User'
+                    message: User information updated successfully
+
+        '400':
+          description: 잘못된 요청 (허용되지 않은 필드 포함 등)
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                invalidRequest:
+                  summary: 잘못된 요청
+                  value:
+                    success: false
+                    message: Invalid request, possibly due to unsupported fields
+
+        '401':
+          description: 인증 실패 (토큰이 없거나 유효하지 않음)
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                unauthorized:
+                  summary: 인증 실패
+                  value:
+                    success: false
+                    message: User ID is required
+
+        '404':
+          description: 사용자 정보 없음
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                userNotFound:
+                  summary: 사용자 정보 없음
+                  value:
+                    success: false
+                    message: User not found
+
+        '500':
+          description: 서버 오류
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                serverError:
+                  summary: 서버 오류
+                  value:
+                    success: false
+                    message: Internal server error
+
 components:
   schemas:
     PhoneRequest:
@@ -324,6 +401,14 @@ components:
           type: string
           description: 리프레시 토큰
           example: your_refresh_token_here
+
+    UpdateUserInfoRequest:
+      type: object
+      properties:
+        nickname:
+          type: string
+          description: 사용자 닉네임
+          example: '새로운 닉네임'
 
     PhoneVerifySuccessResponse:
       type: object


### PR DESCRIPTION
# Changelog
- 해당 사용자 ID에 대해 User가 없는 경우 404 에러를 반환할 수 있도록 수정하였습니다.
- Swagger API 명세에 PATCH User 부분을 추가하였습니다.

# Testing
- Swagger에 명세 확인
<img width="1433" height="962" alt="image" src="https://github.com/user-attachments/assets/153a6146-ee4d-4285-aae5-4c9d862f0b33" />

- Unit Test
<img width="694" height="859" alt="image" src="https://github.com/user-attachments/assets/e1364498-0dcf-41b6-87de-215f43b07d51" />

# Ops Impact
N/A

# Version Compatibility
N/A