### PR TITLE
[Server] 사용자가 생성될 때 Section별 선호도 생성

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -7,7 +7,7 @@
     "predev": "pnpm run api-docs",
     "dev": "nodemon main.ts",
     "test": "jest",
-    "init_db": "npx prisma migrate deploy && npx prisma generate",
+    "init_db": "npx prisma migrate deploy && npx prisma generate && npx ts-node ./prisma/seed.ts",
     "api-docs": "swagger-cli bundle ./src/swagger/openapi.yaml --outfile build/swagger.yaml --type yaml"
   },
   "dependencies": {

--- a/server/prisma/migrations/20250726120202_add_user_section_relation/migration.sql
+++ b/server/prisma/migrations/20250726120202_add_user_section_relation/migration.sql
@@ -1,0 +1,14 @@
+-- CreateTable
+CREATE TABLE `user_article_section_preference` (
+    `user_id` INTEGER NOT NULL,
+    `section_id` INTEGER NOT NULL,
+    `preference` INTEGER NOT NULL DEFAULT 1,
+
+    PRIMARY KEY (`user_id`, `section_id`)
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+-- AddForeignKey
+ALTER TABLE `user_article_section_preference` ADD CONSTRAINT `user_article_section_preference_user_id_fkey` FOREIGN KEY (`user_id`) REFERENCES `user`(`id`) ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE `user_article_section_preference` ADD CONSTRAINT `user_article_section_preference_section_id_fkey` FOREIGN KEY (`section_id`) REFERENCES `article_section`(`id`) ON DELETE CASCADE ON UPDATE CASCADE;

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -29,7 +29,8 @@ model ArticleSection {
   id   Int         @id @default(autoincrement())
   name SectionType @unique
 
-  p_articles ProcessedArticle[]
+  p_articles                      ProcessedArticle[]
+  user_article_section_preference UserArticleSectionPreference[]
 
   @@map("article_section")
 }
@@ -101,9 +102,10 @@ model User {
   created_at       DateTime @default(now())
   updated_at       DateTime @default(now()) @updatedAt
 
-  refreshTokens RefreshToken?
-  likes         Like[]
-  scraps        Scrap[]
+  refreshTokens                   RefreshToken?
+  likes                           Like[]
+  scraps                          Scrap[]
+  user_article_section_preference UserArticleSectionPreference[]
 
   @@map("user")
 }
@@ -144,4 +146,16 @@ model Scrap {
 
   @@id([p_article_id, user_id])
   @@map("scrap")
+}
+
+model UserArticleSectionPreference {
+  user_id    Int
+  section_id Int
+  preference Int @default(1)
+
+  user    User           @relation(fields: [user_id], references: [id], onDelete: Cascade)
+  section ArticleSection @relation(fields: [section_id], references: [id], onDelete: Cascade)
+
+  @@id([user_id, section_id])
+  @@map("user_article_section_preference")
 }

--- a/server/prisma/seed.ts
+++ b/server/prisma/seed.ts
@@ -1,0 +1,42 @@
+import { PrismaClient, SectionType } from '@prisma/client'
+
+const prisma = new PrismaClient()
+
+/**
+ * 기본 뉴스 섹션을 데이터베이스에 추가하는 스크립트입니다.
+ * 이 스크립트는 뉴스 섹션을 데이터베이스에 삽입하거나 이미 존재하는 경우 업데이트합니다.
+ * 각 섹션은 고유한 이름을 가지고 있으며, 다음과 같은 섹션이 포함됩니다:
+ * - 정치 (politics)
+ *   경제 (economy)
+ *   사회 (society)
+ *   문화 (culture)
+ *   기술 (tech)
+ *   세계 (world)
+ */
+async function main() {
+  const sections = [
+    SectionType.politics,
+    SectionType.economy,
+    SectionType.society,
+    SectionType.culture,
+    SectionType.tech,
+    SectionType.world,
+  ]
+
+  for (const name of sections) {
+    await prisma.articleSection.upsert({
+      where: { name },
+      update: {}, // 이미 있으면 변경하지 않음
+      create: { name },
+    })
+  }
+}
+
+main()
+  .catch((e) => {
+    console.error(e)
+    process.exit(1)
+  })
+  .finally(async () => {
+    await prisma.$disconnect()
+  })

--- a/server/src/services/__tests__/userService.test.ts
+++ b/server/src/services/__tests__/userService.test.ts
@@ -1,6 +1,6 @@
 import { UserNotFoundError, userService } from '../userService'
 import { prismaMock } from '../../../prisma/mock'
-import { User } from '@prisma/client'
+import { User, ArticleSection } from '@prisma/client'
 import { PrismaClientKnownRequestError } from '@prisma/client/runtime/library'
 
 describe('userService', () => {
@@ -59,6 +59,7 @@ describe('userService', () => {
     it('should create and return new user', async () => {
       const createdUser = { ...mockUser, id: 2 }
       ;(prismaMock.user.create as jest.Mock).mockResolvedValue(createdUser)
+      ;(prismaMock.articleSection.findMany as jest.Mock).mockResolvedValue([])
 
       const result = await userService.createUser('01087654321', '새유저', true)
 
@@ -67,9 +68,42 @@ describe('userService', () => {
           phone: '01087654321',
           nickname: '새유저',
           is_authenticated: true,
+          user_article_section_preference: {
+            create: [],
+          },
+        },
+        include: {
+          user_article_section_preference: true,
         },
       })
       expect(result).toEqual(createdUser)
+    })
+
+    it('should create default section preferences for new user', async () => {
+      const sections = [
+        { id: 1, name: 'politics' },
+        { id: 2, name: 'economy' },
+      ]
+      ;(prismaMock.articleSection.findMany as jest.Mock).mockResolvedValue(sections)
+
+      const createdUser = { ...mockUser, id: 2 }
+      ;(prismaMock.user.create as jest.Mock).mockResolvedValue(createdUser)
+
+      await userService.createUser('01087654321', '새유저', true)
+
+      expect(prismaMock.user.create).toHaveBeenCalledWith({
+        data: {
+          phone: '01087654321',
+          nickname: '새유저',
+          is_authenticated: true,
+          user_article_section_preference: {
+            create: sections.map((section) => ({ section_id: section.id })),
+          },
+        },
+        include: {
+          user_article_section_preference: true,
+        },
+      })
     })
   })
 

--- a/server/src/services/userService.ts
+++ b/server/src/services/userService.ts
@@ -45,6 +45,7 @@ export const userService = {
 
   /**
    * 새로운 사용자를 생성합니다.
+   * 기본적으로 현재 존재하는 Section들에 대한 선호도를 Default 선호도로 설정합니다.
    *
    * @async
    * @param {string} phoneNumber - 생성할 사용자의 휴대폰 번호
@@ -53,13 +54,26 @@ export const userService = {
    * @returns {Promise<User>} 생성된 사용자 객체
    */
   createUser: async (phoneNumber: string, nickname: string, isAuthenticated: boolean): Promise<User> => {
+    // NOTE: 현재 존재하는 Section들에 대한 기본 선호도를 생성합니다.
+    const sections = await prisma.articleSection.findMany()
+    const defaultSectionPrefs = sections.map((section) => ({
+      section_id: section.id,
+    }))
+
     const user = await prisma.user.create({
       data: {
         phone: phoneNumber,
         nickname: nickname,
         is_authenticated: isAuthenticated,
+        user_article_section_preference: {
+          create: defaultSectionPrefs,
+        },
+      },
+      include: {
+        user_article_section_preference: true,
       },
     })
+
     return user
   },
 


### PR DESCRIPTION
# Changelog
- `UserArticleSectionPreference` 테이블을 생성하여 user와 section 사이의 선호도를 저장할 수 있도록 하였습니다.
- 사용자가 생성될 때 Section별 선호도를 Default 1로 설정하도록 하였습니다.
- `seed.ts`를 작성하여 `pnpm init_db`를 실행하면 6개의 영역이 바로 생성되도록 하였습니다.

# Testing
- 유저가 생성된 후 `UserArticleSectionPreference` 테이블 확인
<img width="503" height="219" alt="image" src="https://github.com/user-attachments/assets/5837ddeb-a6e9-4a70-a4be-429e26ec03e6" />

- `pnpm init_db` 실행 후 `ArticleSection` 테이블 확인
<img width="227" height="186" alt="image" src="https://github.com/user-attachments/assets/b7d422ea-aac8-484f-bf61-1875712f6610" />

- 유닛테스트
<img width="711" height="847" alt="image" src="https://github.com/user-attachments/assets/f604a0da-a475-47fe-9c7e-4623223e48e4" />

# Ops Impact
N/A

# Version Compatibility
N/A