### PR TITLE
[Server] Section 관련 API 구현

### DIFF
--- a/server/build/swagger.yaml
+++ b/server/build/swagger.yaml
@@ -341,6 +341,103 @@ paths:
                   value:
                     success: false
                     message: Internal server error
+  /sections:
+    get:
+      summary: 섹션 목록 조회
+      description: 등록된 섹션 목록을 조회합니다.
+      responses:
+        '200':
+          description: 섹션 목록 조회 성공
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SectionResponse'
+              examples:
+                success:
+                  summary: 섹션 목록 조회 성공
+                  value:
+                    success: true
+                    data:
+                      - id: 1
+                        name: politics
+                      - id: 2
+                        name: economy
+                    message: Sections retrieved successfully
+        '404':
+          description: 섹션 없음
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                sectionNotFound:
+                  summary: 섹션을 찾을 수 없음
+                  value:
+                    success: false
+                    message: Sections not found
+        '500':
+          description: 서버 오류
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                serverError:
+                  summary: 서버 오류
+                  value:
+                    success: false
+                    message: Internal server error
+  '/sections/{id}':
+    get:
+      summary: 특정 섹션 조회
+      description: ID로 특정 섹션을 조회합니다.
+      parameters:
+        - in: path
+          name: id
+          schema:
+            type: integer
+          required: true
+          description: 섹션 ID
+      responses:
+        '200':
+          description: 섹션 조회 성공
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SectionResponse'
+              examples:
+                success:
+                  summary: 섹션 조회 성공
+                  value:
+                    success: true
+                    data:
+                      id: 1
+                      name: politics
+                    message: Section retrieved successfully
+        '404':
+          description: 섹션 없음
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                sectionNotFound:
+                  summary: 섹션을 찾을 수 없음
+                  value:
+                    success: false
+                    message: Section not found
+        '500':
+          description: 서버 오류
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                serverError:
+                  summary: 서버 오류
+                  value:
+                    success: false
+                    message: Internal server error
 components:
   schemas:
     PhoneRequest:
@@ -545,3 +642,23 @@ components:
         message:
           type: string
           example: Article retrieved successfully
+    Section:
+      type: object
+      properties:
+        id:
+          type: integer
+          example: 1
+        name:
+          type: string
+          example: politics
+    SectionResponse:
+      type: object
+      properties:
+        success:
+          type: boolean
+          example: true
+        data:
+          $ref: '#/components/schemas/Section'
+        message:
+          type: string
+          example: Section retrieved successfully

--- a/server/main.ts
+++ b/server/main.ts
@@ -11,6 +11,7 @@ import { redisClient } from './src/config/redis'
 import articleRouter from './src/routes/article'
 import authRouter from './src/routes/auth'
 import userRouter from './src/routes/user'
+import sectionRouter from './src/routes/section'
 
 const swaggerYamlPath = path.join(__dirname, './build/swagger.yaml')
 const swaggerDocument = YAML.load(swaggerYamlPath)
@@ -24,6 +25,7 @@ app.use('/api-docs', swaggerUi.serve, swaggerUi.setup(swaggerDocument))
 app.use('/api/articles', articleRouter)
 app.use('/api/auth', authRouter)
 app.use('/api/users', userRouter)
+app.use('/api/sections', sectionRouter)
 
 const PORT = process.env.PORT || 3000
 

--- a/server/src/controllers/__tests__/sectionController.test.ts
+++ b/server/src/controllers/__tests__/sectionController.test.ts
@@ -1,0 +1,83 @@
+import { sectionService, SectionNotFoundError } from '../../services/sectionService'
+import { success, errors } from '../../utils/response'
+import { getSections, getSectionById } from '../sectionController'
+
+jest.mock('../../utils/response')
+jest.mock('../../services/sectionService')
+
+describe('sectionController', () => {
+  let req: any
+  let res: any
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    req = { query: {}, params: {} }
+    res = {}
+  })
+
+  describe('getSections', () => {
+    it('should return all sections', async () => {
+      const expectedSections = [
+        { id: 1, name: 'politics' },
+        { id: 2, name: 'economy' },
+      ]
+      ;(sectionService.getSections as jest.Mock).mockResolvedValue(expectedSections)
+
+      const sections = await getSections(req, res)
+
+      expect(success).toHaveBeenCalledWith(res, expectedSections, {
+        message: 'Sections retrieved successfully',
+      })
+    })
+
+    it('should return not found error if no sections exist', async () => {
+      ;(sectionService.getSections as jest.Mock).mockRejectedValue(new SectionNotFoundError('Sections not found'))
+
+      await getSections(req, res)
+
+      expect(errors.notFound).toHaveBeenCalledWith(res, 'Sections not found')
+    })
+
+    it('should return internal error on unexpected error', async () => {
+      const error = new Error('Unexpected error')
+      ;(sectionService.getSections as jest.Mock).mockRejectedValue(error)
+
+      await getSections(req, res)
+
+      expect(errors.internal).toHaveBeenCalledWith(res)
+    })
+  })
+
+  describe('getSectionById', () => {
+    it('should return section by id', async () => {
+      req.params.id = '1'
+      const expectedSection = { id: 1, name: 'politics' }
+      ;(sectionService.getSectionById as jest.Mock).mockResolvedValue(expectedSection)
+
+      const section = await getSectionById(req, res)
+
+      expect(success).toHaveBeenCalledWith(res, expectedSection, {
+        message: 'Section retrieved successfully',
+      })
+    })
+
+    it('should return not found error if section does not exist', async () => {
+      req.params.id = '999'
+      ;(sectionService.getSectionById as jest.Mock).mockRejectedValue(new SectionNotFoundError('Section not found'))
+
+      await getSectionById(req, res)
+
+      expect(errors.notFound).toHaveBeenCalledWith(res, 'Section not found')
+    })
+
+    it('should return internal error on unexpected error', async () => {
+      req.params.id = '1'
+      const error = new Error('Unexpected error')
+      ;(sectionService.getSectionById as jest.Mock).mockRejectedValue(error)
+
+      await getSectionById(req, res)
+
+      expect(errors.internal).toHaveBeenCalledWith(res)
+    })
+  })
+})

--- a/server/src/controllers/sectionController.ts
+++ b/server/src/controllers/sectionController.ts
@@ -1,0 +1,67 @@
+import { Request, Response } from 'express'
+import { SectionNotFoundError, sectionService } from '../services/sectionService'
+import { errors, success } from '../utils/response'
+
+/**
+ * 모든 섹션을 조회하는 컨트롤러입니다.
+ * 사용자가 요청하면 데이터베이스에서 모든 섹션을 조회하여 반환합니다.
+ * @param {Request} req - Express 요청 객체.
+ * @param {Response} res - Express 응답 객체.
+ * @example
+ * // 요청 예시
+ * GET /api/sections
+ * // 응답 예시
+ * {
+ *  "data": [
+ *  {
+ *  "id": 1,
+ *  "name": "Technology",
+ *  }
+ *  ]
+ * }
+ */
+export const getSections = async (req: Request, res: Response): Promise<Response> => {
+  try {
+    const sections = await sectionService.getSections()
+    return success(res, sections, {
+      message: 'Sections retrieved successfully',
+    })
+  } catch (error) {
+    if (error instanceof SectionNotFoundError) {
+      return errors.notFound(res, 'Sections not found')
+    }
+    return errors.internal(res)
+  }
+}
+
+/**
+ * 특정 ID의 섹션을 조회하는 컨트롤러입니다.
+ * 사용자가 요청한 ID에 해당하는 섹션을 데이터베이스에서 조회합니다.
+ * @param {Request} req - Express 요청 객체. URL 파라미터로 id가 포함되어야 합니다.
+ * @param {Response} res - Express 응답 객체.
+ * @example
+ * // 요청 예시
+ * GET /api/sections/:id
+ * // 응답 예시
+ * {
+ * "data": {
+ * "id": 1,
+ * "name": "Technology",
+ * }
+ * }
+ */
+export const getSectionById = async (req: Request, res: Response): Promise<Response> => {
+  const id = parseInt(req.params.id, 10)
+
+  try {
+    const section = await sectionService.getSectionById(id)
+    return success(res, section, {
+      message: 'Section retrieved successfully',
+    })
+  } catch (error) {
+    if (error instanceof SectionNotFoundError) {
+      return errors.notFound(res, 'Section not found')
+    }
+    return errors.internal(res)
+  }
+}

--- a/server/src/routes/section.ts
+++ b/server/src/routes/section.ts
@@ -12,3 +12,5 @@ router.get('/', getSections)
  * 특정 섹션 조회
  */
 router.get('/:id', getSectionById)
+
+export default router

--- a/server/src/routes/section.ts
+++ b/server/src/routes/section.ts
@@ -1,0 +1,14 @@
+import { Router } from 'express'
+import { getSectionById, getSections } from '../controllers/sectionController'
+
+const router = Router()
+
+/**
+ * 섹션 목록 조회
+ */
+router.get('/', getSections)
+
+/**
+ * 특정 섹션 조회
+ */
+router.get('/:id', getSectionById)

--- a/server/src/services/__tests__/sectionService.test.ts
+++ b/server/src/services/__tests__/sectionService.test.ts
@@ -1,0 +1,49 @@
+import { prismaMock } from '../../../prisma/mock'
+import { sectionService, SectionNotFoundError } from '../sectionService'
+
+describe('SectionService', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  describe('getSections', () => {
+    it('should return all sections', async () => {
+      const mockSections = [
+        { id: 1, name: 'politics' },
+        { id: 2, name: 'economy' },
+      ]
+
+      ;(prismaMock.articleSection.findMany as jest.Mock).mockResolvedValue(mockSections)
+
+      const sections = await sectionService.getSections()
+
+      expect(prismaMock.articleSection.findMany).toHaveBeenCalled()
+      expect(sections).toEqual(mockSections)
+    })
+
+    it('should throw SectionNotFoundError if no sections found', async () => {
+      ;(prismaMock.articleSection.findMany as jest.Mock).mockResolvedValue([])
+      await expect(sectionService.getSections()).rejects.toThrow(SectionNotFoundError)
+    })
+  })
+
+  describe('getSectionById', () => {
+    it('should return section by id', async () => {
+      const mockSection = { id: 1, name: 'politics' }
+
+      ;(prismaMock.articleSection.findUnique as jest.Mock).mockResolvedValue(mockSection)
+
+      const section = await sectionService.getSectionById(1)
+
+      expect(prismaMock.articleSection.findUnique).toHaveBeenCalledWith({
+        where: { id: 1 },
+      })
+      expect(section).toEqual(mockSection)
+    })
+
+    it('should throw SectionNotFoundError if section not found', async () => {
+      ;(prismaMock.articleSection.findUnique as jest.Mock).mockResolvedValue(null)
+      await expect(sectionService.getSectionById(999)).rejects.toThrow(SectionNotFoundError)
+    })
+  })
+})

--- a/server/src/services/sectionService.ts
+++ b/server/src/services/sectionService.ts
@@ -1,0 +1,51 @@
+import { ArticleSection } from '@prisma/client'
+import { prisma } from '../../prisma/prisma'
+
+/**
+ * 특정 섹션을 찾지 못했을 때 발생하는 오류 클래스입니다.
+ * 이 오류는 섹션이 존재하지 않을 때 사용됩니다.
+ */
+export class SectionNotFoundError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'SectionNotFoundError'
+  }
+}
+
+/**
+ * 섹션 관련 데이터베이스 작업을 처리하는 서비스 객체입니다.
+ */
+export const sectionService = {
+  /**
+   * 모든 섹션을 조회합니다.
+   * @returns {Promise<ArticleSection[]>} - 데이터베이스에 저장된 모든 섹션의 배열
+   * @throws {SectionNotFoundError} - 섹션이 존재하지 않을 경우 발생
+   */
+  getSections: async (): Promise<ArticleSection[]> => {
+    const sections = await prisma.articleSection.findMany()
+
+    if (sections.length === 0) {
+      throw new SectionNotFoundError('Sections not found')
+    }
+
+    return sections
+  },
+
+  /**
+   * 특정 ID의 섹션을 조회합니다.
+   * @param {number} id - 조회할 섹션의 ID
+   * @returns {Promise<ArticleSection>} - 해당 ID의 섹션 객체
+   * @throws {SectionNotFoundError} - 섹션이 존재하지 않을 경우 발생
+   */
+  getSectionById: async (id: number): Promise<ArticleSection> => {
+    const section = await prisma.articleSection.findUnique({
+      where: { id },
+    })
+
+    if (!section) {
+      throw new SectionNotFoundError('Section not found')
+    }
+
+    return section
+  },
+}

--- a/server/src/swagger/openapi.yaml
+++ b/server/src/swagger/openapi.yaml
@@ -365,6 +365,109 @@ paths:
                     success: false
                     message: Internal server error
 
+  /sections:
+    get:
+      summary: 섹션 목록 조회
+      description: 등록된 섹션 목록을 조회합니다.
+      responses:
+        '200':
+          description: 섹션 목록 조회 성공
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SectionResponse'
+              examples:
+                success:
+                  summary: 섹션 목록 조회 성공
+                  value:
+                    success: true
+                    data:
+                      - id: 1
+                        name: 'politics'
+                      - id: 2
+                        name: 'economy'
+                    message: Sections retrieved successfully
+
+        '404':
+          description: 섹션 없음
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                sectionNotFound:
+                  summary: 섹션을 찾을 수 없음
+                  value:
+                    success: false
+                    message: Sections not found
+
+        '500':
+          description: 서버 오류
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                serverError:
+                  summary: 서버 오류
+                  value:
+                    success: false
+                    message: Internal server error
+
+  /sections/{id}:
+    get:
+      summary: 특정 섹션 조회
+      description: ID로 특정 섹션을 조회합니다.
+      parameters:
+        - in: path
+          name: id
+          schema:
+            type: integer
+          required: true
+          description: 섹션 ID
+      responses:
+        '200':
+          description: 섹션 조회 성공
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SectionResponse'
+              examples:
+                success:
+                  summary: 섹션 조회 성공
+                  value:
+                    success: true
+                    data:
+                      id: 1
+                      name: 'politics'
+                    message: Section retrieved successfully
+
+        '404':
+          description: 섹션 없음
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                sectionNotFound:
+                  summary: 섹션을 찾을 수 없음
+                  value:
+                    success: false
+                    message: Section not found
+
+        '500':
+          description: 서버 오류
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                serverError:
+                  summary: 서버 오류
+                  value:
+                    success: false
+                    message: Internal server error
+
 components:
   schemas:
     PhoneRequest:
@@ -580,3 +683,25 @@ components:
         message:
           type: string
           example: Article retrieved successfully
+
+    Section:
+      type: object
+      properties:
+        id:
+          type: integer
+          example: 1
+        name:
+          type: string
+          example: 'politics'
+
+    SectionResponse:
+      type: object
+      properties:
+        success:
+          type: boolean
+          example: true
+        data:
+          $ref: '#/components/schemas/Section'
+        message:
+          type: string
+          example: Section retrieved successfully


### PR DESCRIPTION
# Changelog
- `ArticleSection` 테이블과 관련된 연산을 수행하는 `sectionService`를 작성하였습니다.
  - 전체 Section을 조회하는 기능과 특정 ID를 가진 Section을 조회하는 기능을 포함합니다.
- Section과 관련된 요청을 처리하는 `sectionController`를 작성하였습니다.
  - `GET /api/sections`: 모든 섹션 반환
  - `GET /api/sections/:id`: 특정 ID의 섹션 반환

# Testing
- `GET /api/sections`
<img width="986" height="851" alt="image" src="https://github.com/user-attachments/assets/ba4682e4-7e06-48b2-9abc-3aafdb519661" />

- `GET /api/sections/1`
<img width="1005" height="444" alt="image" src="https://github.com/user-attachments/assets/15c8b975-c6c9-4392-8ca7-8a4579193399" />

- Unit Test
<img width="860" height="915" alt="image" src="https://github.com/user-attachments/assets/994606f0-5f37-44f4-ba9a-f7e20ca2bfd2" />

# Ops Impact
N/A

# Version Compatibility
N/A