### PR TITLE
[Server] 사용자별 영역 선호도 업데이트 API 구현

### DIFF
--- a/server/build/swagger.yaml
+++ b/server/build/swagger.yaml
@@ -341,6 +341,59 @@ paths:
                   value:
                     success: false
                     message: Internal server error
+  /users/section-preferences:
+    patch:
+      summary: 사용자 섹션 선호도 업데이트
+      description: 사용자의 섹션 선호도를 업데이트합니다.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UserSectionPreferences'
+      responses:
+        '200':
+          description: 사용자 섹션 선호도 업데이트 성공
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UserSectionPreferencesResponse'
+        '400':
+          description: 잘못된 요청 (필드 타입 오류 등)
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                invalidRequest:
+                  summary: 잘못된 요청
+                  value:
+                    success: false
+                    message: 'Invalid request body, please check body format'
+        '401':
+          description: 인증 실패 (토큰이 없거나 유효하지 않음)
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                unauthorized:
+                  summary: 인증 실패
+                  value:
+                    success: false
+                    message: User ID is required
+        '500':
+          description: 서버 오류
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                serverError:
+                  summary: 서버 오류
+                  value:
+                    success: false
+                    message: Internal server error
   /sections:
     get:
       summary: 섹션 목록 조회
@@ -662,3 +715,28 @@ components:
         message:
           type: string
           example: Section retrieved successfully
+    UserSectionPreferences:
+      type: object
+      properties:
+        userId:
+          type: integer
+          example: 1
+        sectionId:
+          type: integer
+          example: 2
+        preferences:
+          type: integer
+          example: 2
+    UserSectionPreferencesResponse:
+      type: object
+      properties:
+        success:
+          type: boolean
+          example: true
+        data:
+          type: array
+          items:
+            $ref: '#/components/schemas/UserSectionPreferences'
+        message:
+          type: string
+          example: User section preferences updated successfully

--- a/server/src/controllers/__tests__/userController.test.ts
+++ b/server/src/controllers/__tests__/userController.test.ts
@@ -219,10 +219,10 @@ describe('updateUserSectionPreferences', () => {
   })
 
   it('should update user section preferences', async () => {
-    const preferences = [
-      { sectionId: 1, preference: 1 },
-      { sectionId: 2, preference: 2 },
-    ]
+    const preferences = [{ sectionId: 1, preference: 1 }]
+    const updatedPrefs = [{ sectionId: 1, preference: 1 }]
+
+    ;(userService.updateUserSectionPreferences as jest.Mock).mockResolvedValue(updatedPrefs)
 
     const req = {
       userId: 1,
@@ -234,7 +234,7 @@ describe('updateUserSectionPreferences', () => {
     await updateUserSectionPreferences(req, res)
 
     expect(userService.updateUserSectionPreferences).toHaveBeenCalledWith(1, preferences)
-    expect(success).toHaveBeenCalledWith(res, null, {
+    expect(success).toHaveBeenCalledWith(res, updatedPrefs, {
       message: 'User section preferences updated successfully',
     })
   })

--- a/server/src/controllers/userController.ts
+++ b/server/src/controllers/userController.ts
@@ -88,6 +88,22 @@ export const updateUser = async (req: AuthenticatedRequest, res: Response): Prom
   }
 }
 
+/**
+ * 사용자의 섹션 선호도를 업데이트하는 컨트롤러입니다.
+ * 사용자가 인증된 상태에서 자신의 섹션 선호도를 변경할 수 있습니다.
+ * @param {AuthenticatedRequest} req - 인증된 사용자 요청 객체. userId와 body에 섹션 선호도가 포함되어야 합니다.
+ * @param {Response} res - Express 응답 객체.
+ * @example
+ * // 요청 예시
+ * PATCH /api/user/section-preferences
+ * [
+ *  {
+ *  "sectionId": 1,
+ *  "preference": 1
+ *  }
+ * ]
+ * @returns {Promise<Response>} 업데이트된 섹션 선호도를 포함한 응답 객체
+ */
 export const updateUserSectionPreferences = async (req: AuthenticatedRequest, res: Response): Promise<Response> => {
   try {
     const userId = req.userId

--- a/server/src/controllers/userController.ts
+++ b/server/src/controllers/userController.ts
@@ -3,7 +3,6 @@ import { Response } from 'express'
 import { errors, success } from '../utils/response'
 import { AuthenticatedRequest } from '../middlewares/authenticateJWT'
 import { UserNotFoundError, userService } from '../services/userService'
-import { UpdateUserRequest, UserSectionPreference } from '../types/user'
 
 /**
  * 사용자의 닉네임을 업데이트하는 컨트롤러입니다.
@@ -106,12 +105,12 @@ export const updateUserSectionPreferences = async (req: AuthenticatedRequest, re
     const updateUserSectionPrefsSchema = z.array(userSectionPrefSchema)
 
     const parsed = updateUserSectionPrefsSchema.safeParse(req.body)
-    if (!parsed.success) {
+    if (!parsed.success || parsed.data.length === 0) {
       return errors.badRequest(res, 'Invalid request body, please check body format')
     }
 
-    await userService.updateUserSectionPreferences(userId, parsed.data)
-    return success(res, null, {
+    const updatedPrefs = await userService.updateUserSectionPreferences(userId, parsed.data)
+    return success(res, updatedPrefs, {
       message: 'User section preferences updated successfully',
     })
   } catch (error) {

--- a/server/src/routes/user.ts
+++ b/server/src/routes/user.ts
@@ -1,6 +1,6 @@
 import { Router } from 'express'
 import { authenticateJWT } from '../middlewares/authenticateJWT'
-import { updateNickname, updateUser } from '../controllers/userController'
+import { updateUser, updateUserSectionPreferences } from '../controllers/userController'
 
 const router = Router()
 
@@ -8,5 +8,10 @@ const router = Router()
  * 사용자 닉네임 업데이트
  */
 router.patch('/', authenticateJWT, updateUser)
+
+/**
+ * 사용자 섹션 선호도 업데이트
+ */
+router.patch('/section-preferences', authenticateJWT, updateUserSectionPreferences)
 
 export default router

--- a/server/src/services/__tests__/userService.test.ts
+++ b/server/src/services/__tests__/userService.test.ts
@@ -175,15 +175,7 @@ describe('userService', () => {
   })
 
   describe('updateUserSectionPreferences', () => {
-    it('should return immediately if preferences are empty', async () => {
-      const preferences: UserSectionPreference[] = []
-
-      await expect(userService.updateUserSectionPreferences(1, preferences)).resolves.toBeUndefined()
-      expect(prismaMock.articleSection.findMany).not.toHaveBeenCalled()
-      expect(prismaMock.userArticleSectionPreference.upsert).not.toHaveBeenCalled()
-    })
-
-    it('should upsert user section preferences', async () => {
+    it('should upsert user section preferences and return updated preferences', async () => {
       const preferences: UserSectionPreference[] = [
         { sectionId: 1, preference: 1 },
         { sectionId: 2, preference: 2 },
@@ -229,6 +221,10 @@ describe('userService', () => {
           section_id: 2,
           preference: 2,
         },
+      })
+
+      expect(prismaMock.userArticleSectionPreference.findMany).toHaveBeenCalledWith({
+        where: { user_id: 1 },
       })
     })
 

--- a/server/src/services/userService.ts
+++ b/server/src/services/userService.ts
@@ -130,6 +130,15 @@ export const userService = {
     }
   },
 
+  /**
+   * 사용자의 섹션 선호도를 업데이트합니다.
+   * 중복된 sectionId를 제거하고 유효한 sectionId만 필터링하여 업데이트합니다.
+   * 이 작업은 병렬로 실행되어 성능을 최적화합니다.
+   * @param {number} userId - 섹션 선호도를 업데이트할 사용자의 ID
+   * @param {UserSectionPreference[]} preferences - 업데이트할 섹션 선호도 배열
+   * @returns {Promise<UserArticleSectionPreference[]>} 업데이트된 사용자 섹션 선호도 배열
+   * @throws {Error} - 섹션 선호도 업데이트 실패 시 오류 발생
+   */
   updateUserSectionPreferences: async (
     userId: number,
     preferences: UserSectionPreference[],

--- a/server/src/swagger/openapi.yaml
+++ b/server/src/swagger/openapi.yaml
@@ -365,6 +365,63 @@ paths:
                     success: false
                     message: Internal server error
 
+  /users/section-preferences:
+    patch:
+      summary: 사용자 섹션 선호도 업데이트
+      description: 사용자의 섹션 선호도를 업데이트합니다.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UserSectionPreferences'
+      responses:
+        '200':
+          description: 사용자 섹션 선호도 업데이트 성공
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UserSectionPreferencesResponse'
+
+        '400':
+          description: 잘못된 요청 (필드 타입 오류 등)
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                invalidRequest:
+                  summary: 잘못된 요청
+                  value:
+                    success: false
+                    message: Invalid request body, please check body format
+
+        '401':
+          description: 인증 실패 (토큰이 없거나 유효하지 않음)
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                unauthorized:
+                  summary: 인증 실패
+                  value:
+                    success: false
+                    message: User ID is required
+
+        '500':
+          description: 서버 오류
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                serverError:
+                  summary: 서버 오류
+                  value:
+                    success: false
+                    message: Internal server error
+
   /sections:
     get:
       summary: 섹션 목록 조회
@@ -705,3 +762,30 @@ components:
         message:
           type: string
           example: Section retrieved successfully
+
+    UserSectionPreferences:
+      type: object
+      properties:
+        userId:
+          type: integer
+          example: 1
+        sectionId:
+          type: integer
+          example: 2
+        preferences:
+          type: integer
+          example: 2
+
+    UserSectionPreferencesResponse:
+      type: object
+      properties:
+        success:
+          type: boolean
+          example: true
+        data:
+          type: array
+          items:
+            $ref: '#/components/schemas/UserSectionPreferences'
+        message:
+          type: string
+          example: User section preferences updated successfully

--- a/server/src/types/user.ts
+++ b/server/src/types/user.ts
@@ -1,0 +1,14 @@
+/**
+ * 사용자 정보를 업데이트하는 요청 형태입니다.
+ */
+export type UpdateUserRequest = {
+  nickname?: string
+}
+
+/**
+ * 사용자 섹션 선호도를 정의하는 타입입니다.
+ */
+export type UserSectionPreference = {
+  sectionId: number
+  preference: number
+}


### PR DESCRIPTION
# Changelog
- 사용자별로 `UserSectionPreference` 테이블을 업데이트하는 API를 구현하였습니다.
- Controller와 Service 간에 순환 참조를 방지하기 위해 타입 정의를 `/types/user.ts`에 분리하였습니다.

# Testing
- API 호출
<img width="1003" height="549" alt="image" src="https://github.com/user-attachments/assets/60620bd3-797e-4958-b372-1f1495467705" />

- 결과
<img width="489" height="181" alt="image" src="https://github.com/user-attachments/assets/68fc3f0b-96dd-4d41-89fa-2bb2a3c7c311" />

- 유닛테스트
<img width="711" height="895" alt="image" src="https://github.com/user-attachments/assets/13756b82-14bb-4b60-b656-03c884cb8e01" />

# Ops Impact
N/A

# Version Compatibility
N/A