### PR TITLE
[Server] 로그인 시 신규/기존 사용자 Flag 추가

### DIFF
--- a/server/build/swagger.yaml
+++ b/server/build/swagger.yaml
@@ -74,6 +74,35 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/PhoneVerifySuccessResponse'
+              examples:
+                successWithNewUser:
+                  summary: 신규 사용자 인증 성공
+                  value:
+                    success: true
+                    data:
+                      user:
+                        id: 1
+                        phone: 01012345678
+                        nickname: 슈퍼파워알파
+                      tokens:
+                        accessToken: <access_token>
+                        refreshToken: <refresh_token>
+                      isCreated: true
+                    message: Phone verification successful
+                successWithExistingUser:
+                  summary: 기존 사용자 인증 성공
+                  value:
+                    success: true
+                    data:
+                      user:
+                        id: 2
+                        phone: 01087654321
+                        nickname: 기존사용자닉네임
+                      tokens:
+                        accessToken: <access_token>
+                        refreshToken: <refresh_token>
+                      isCreated: false
+                    message: Phone verification successful
         '400':
           description: 잘못된 요청 (파라미터 누락)
           content:
@@ -545,6 +574,9 @@ components:
               $ref: '#/components/schemas/User'
             tokens:
               $ref: '#/components/schemas/Tokens'
+            isCreated:
+              type: boolean
+              example: true
         message:
           type: string
           example: Phone verification successful

--- a/server/src/controllers/__tests__/authController.test.ts
+++ b/server/src/controllers/__tests__/authController.test.ts
@@ -94,6 +94,7 @@ describe('verifyPhoneAuth', () => {
       {
         user: { id: 1, phone: '010', nickname: '닉네임' },
         tokens: { accessToken: 'A', refreshToken: 'R' },
+        isCreated: false,
       },
       {
         message: 'Phone verification successful',
@@ -119,6 +120,7 @@ describe('verifyPhoneAuth', () => {
       {
         user: { id: 1, phone: '010', nickname: '랜덤닉네임' },
         tokens: { accessToken: 'A', refreshToken: 'R' },
+        isCreated: true,
       },
       {
         message: 'Phone verification successful',

--- a/server/src/controllers/authController.ts
+++ b/server/src/controllers/authController.ts
@@ -67,9 +67,11 @@ export const verifyPhoneAuth = async (req: Request, res: Response) => {
     }
 
     let user = await userService.findUserByPhone(phoneNumber)
+    let isCreated: Boolean = false
     if (!user) {
       const nickname = await generateRandomNickname()
       user = await userService.createUser(phoneNumber, nickname, true)
+      isCreated = true
     }
 
     const tokens = await authService.generateTokens(user.id)
@@ -81,6 +83,7 @@ export const verifyPhoneAuth = async (req: Request, res: Response) => {
         nickname: user.nickname,
       },
       tokens,
+      isCreated,
     }
 
     return success(res, userData, {

--- a/server/src/swagger/openapi.yaml
+++ b/server/src/swagger/openapi.yaml
@@ -78,6 +78,35 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/PhoneVerifySuccessResponse'
+              examples:
+                successWithNewUser:
+                  summary: 신규 사용자 인증 성공
+                  value:
+                    success: true
+                    data:
+                      user:
+                        id: 1
+                        phone: '01012345678'
+                        nickname: '슈퍼파워알파'
+                      tokens:
+                        accessToken: <access_token>
+                        refreshToken: <refresh_token>
+                      isCreated: true
+                    message: Phone verification successful
+                successWithExistingUser:
+                  summary: 기존 사용자 인증 성공
+                  value:
+                    success: true
+                    data:
+                      user:
+                        id: 2
+                        phone: '01087654321'
+                        nickname: '기존사용자닉네임'
+                      tokens:
+                        accessToken: <access_token>
+                        refreshToken: <refresh_token>
+                      isCreated: false
+                    message: Phone verification successful
 
         '400':
           description: 잘못된 요청 (파라미터 누락)
@@ -583,6 +612,9 @@ components:
               $ref: '#/components/schemas/User'
             tokens:
               $ref: '#/components/schemas/Tokens'
+            isCreated:
+              type: boolean
+              example: true
         message:
           type: string
           example: Phone verification successful


### PR DESCRIPTION
# Changelog
- 사용자 로그인 시 기존에 있던 사용자인지, 새로 생성된 사용자인지 구분하기 위해 `isCreated` 플래그를 추가하였습니다.

# Testing
- 새로운 사용자
<img width="1012" height="653" alt="image" src="https://github.com/user-attachments/assets/142e0453-28e7-46bc-8ed2-32a12f84b206" />

- 기존 사용자
<img width="1009" height="653" alt="image" src="https://github.com/user-attachments/assets/8490624d-38dd-42d6-8c83-fe301902a77a" />

- 유닛테스트
<img width="858" height="919" alt="image" src="https://github.com/user-attachments/assets/45ddb564-2ff8-42ba-a434-65e20e54f4fb" />

# Ops Impact
N/A

# Version Compatibility
N/A