### PR TITLE
[Server] 게스트 로그인 구현

### DIFF
--- a/server/build/swagger.yaml
+++ b/server/build/swagger.yaml
@@ -151,6 +151,45 @@ paths:
                   value:
                     success: false
                     message: Internal server error
+  /auth/guest-login:
+    post:
+      summary: 게스트 로그인
+      description: |
+        게스트 사용자를 위한 임시 로그인 기능입니다. 사용자 전화번호는 `GUEST-<idx>` 형식으로 생성됩니다.
+      responses:
+        '200':
+          description: '게스트 로그인 성공, 액세스 토큰 반환'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PhoneVerifySuccessResponse'
+              examples:
+                successWithNewUser:
+                  summary: 게스트 사용자 생성 성공
+                  value:
+                    success: true
+                    data:
+                      user:
+                        id: 1
+                        phone: GUEST-1
+                        nickname: 슈퍼파워알파
+                      tokens:
+                        accessToken: <access_token>
+                        refreshToken: <refresh_token>
+                      isCreated: true
+                    message: Guest login successful
+        '500':
+          description: 서버 오류
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                serverError:
+                  summary: 서버 오류
+                  value:
+                    success: false
+                    message: Internal server error
   /auth/refresh:
     post:
       summary: 액세스 토큰 갱신

--- a/server/src/routes/auth.ts
+++ b/server/src/routes/auth.ts
@@ -1,5 +1,5 @@
 import { Router } from 'express'
-import { refreshAccessToken, requestPhoneAuth, verifyPhoneAuth } from '../controllers/authController'
+import { guestLogin, refreshAccessToken, requestPhoneAuth, verifyPhoneAuth } from '../controllers/authController'
 
 const router = Router()
 
@@ -14,6 +14,12 @@ router.post('/phone/request', requestPhoneAuth)
  * POST /phone/verify
  */
 router.post('/phone/verify', verifyPhoneAuth)
+
+/**
+ * Guest 사용자 생성
+ * POST /guest-login
+ */
+router.post('/guest-login', guestLogin)
 
 /**
  * Access Token 갱신

--- a/server/src/swagger/openapi.yaml
+++ b/server/src/swagger/openapi.yaml
@@ -160,6 +160,47 @@ paths:
                     success: false
                     message: Internal server error
 
+  /auth/guest-login:
+    post:
+      summary: 게스트 로그인
+      description: |
+        게스트 사용자를 위한 임시 로그인 기능입니다. 사용자 전화번호는 `GUEST-<idx>` 형식으로 생성됩니다.
+      responses:
+        '200':
+          description: 게스트 로그인 성공, 액세스 토큰 반환
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PhoneVerifySuccessResponse'
+              examples:
+                successWithNewUser:
+                  summary: 게스트 사용자 생성 성공
+                  value:
+                    success: true
+                    data:
+                      user:
+                        id: 1
+                        phone: 'GUEST-1'
+                        nickname: '슈퍼파워알파'
+                      tokens:
+                        accessToken: <access_token>
+                        refreshToken: <refresh_token>
+                      isCreated: true
+                    message: Guest login successful
+
+        '500':
+          description: 서버 오류
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                serverError:
+                  summary: 서버 오류
+                  value:
+                    success: false
+                    message: Internal server error
+
   /auth/refresh:
     post:
       summary: 액세스 토큰 갱신

--- a/server/src/utils/__tests__/nickname.test.ts
+++ b/server/src/utils/__tests__/nickname.test.ts
@@ -1,4 +1,4 @@
-import { generateRandomNickname } from '../nickname'
+import { generateGuestPhoneNumber, generateRandomNickname } from '../generate'
 import { redisClient } from '../../config/redis'
 
 jest.mock('../../config/redis', () => ({
@@ -20,5 +20,18 @@ describe('generateRandomNickname', () => {
     // 닉네임 형식: "형용사 동물 #1"
     expect(nickname).toBe('귀여운 고양이 #1')
     expect(redisClient.incr).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('generateGuestPhoneNumber', () => {
+  it('Returns a guest phone number with unique index', async () => {
+    // Redis의 incr 메서드가 1을 반환하도록 mock
+    ;(redisClient.incr as jest.Mock).mockResolvedValue(1)
+
+    const phoneNumber = await generateGuestPhoneNumber()
+
+    // 전화번호 형식: "GUEST-1"
+    expect(phoneNumber).toBe('GUEST-1')
+    expect(redisClient.incr).toHaveBeenCalledWith('guest_index')
   })
 })

--- a/server/src/utils/generate.ts
+++ b/server/src/utils/generate.ts
@@ -26,3 +26,11 @@ export const generateRandomNickname = async (): Promise<string> => {
 
   return `${nickname} #${idx}`
 }
+
+export const generateGuestPhoneNumber = async (): Promise<string> => {
+  // Redis에 guest_index 키를 incr하여 고유한 번호 생성
+  const idx = await redisClient.incr('guest_index')
+  const phoneNumber = `GUEST-${String(idx)}`
+
+  return phoneNumber
+}


### PR DESCRIPTION
# Changelog
- `POST /api/auth/guest-login`에 게스트 로그인 기능을 구현하였습니다.
- Redis에 게스트의 인덱스를 저장하고, 전화번호를 `GUEST-{idx}`, 닉네임은 랜덤 닉네임으로 게스트 사용자를 생성합니다.
- Swagger에 API를 명세하였습니다.

# Testing
- Postman 테스트
<img width="1002" height="536" alt="image" src="https://github.com/user-attachments/assets/53b4eee6-1c7c-4668-ad36-0a59a27f9b90" />

- 유닛테스트
<img width="758" height="915" alt="image" src="https://github.com/user-attachments/assets/6034243e-6edc-4b07-9d85-3bfe601a1ef4" />


# Ops Impact
N/A

# Version Compatibility
N/A