### PR TITLE
[Server] 사용자 VIEW 이벤트 저장 API 구현

### DIFF
--- a/server/.gitignore
+++ b/server/.gitignore
@@ -1,3 +1,4 @@
 node_modules/
 .env
 coverage/
+build/

--- a/server/prisma/migrations/20250805034259_create_view_event_table/migration.sql
+++ b/server/prisma/migrations/20250805034259_create_view_event_table/migration.sql
@@ -1,0 +1,16 @@
+-- CreateTable
+CREATE TABLE `article_view_event` (
+    `id` INTEGER NOT NULL AUTO_INCREMENT,
+    `user_id` INTEGER NOT NULL,
+    `p_article_id` INTEGER NOT NULL,
+    `event_type` ENUM('VIEW', 'DETAIL_VIEW') NOT NULL,
+    `event_at` DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+
+    PRIMARY KEY (`id`)
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+-- AddForeignKey
+ALTER TABLE `article_view_event` ADD CONSTRAINT `article_view_event_user_id_fkey` FOREIGN KEY (`user_id`) REFERENCES `user`(`id`) ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE `article_view_event` ADD CONSTRAINT `article_view_event_p_article_id_fkey` FOREIGN KEY (`p_article_id`) REFERENCES `processed_article`(`id`) ON DELETE CASCADE ON UPDATE CASCADE;

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -51,7 +51,8 @@ model ProcessedArticle {
   likes    Like[]
   scraps   Scrap[]
 
-  section ArticleSection @relation(fields: [section_id], references: [id], onDelete: Cascade)
+  section          ArticleSection     @relation(fields: [section_id], references: [id], onDelete: Cascade)
+  ArticleViewEvent ArticleViewEvent[]
 
   @@map("processed_article")
 }
@@ -107,6 +108,7 @@ model User {
   likes                           Like[]
   scraps                          Scrap[]
   user_article_section_preference UserArticleSectionPreference[]
+  ArticleViewEvent                ArticleViewEvent[]
 
   @@map("user")
 }
@@ -159,4 +161,22 @@ model UserArticleSectionPreference {
 
   @@id([user_id, section_id])
   @@map("user_article_section_preference")
+}
+
+enum ArticleViewEventType {
+  VIEW // 일반 조회
+  DETAIL_VIEW // 상세 조회
+}
+
+model ArticleViewEvent {
+  id           Int                  @id @default(autoincrement())
+  user_id      Int
+  p_article_id Int
+  event_type   ArticleViewEventType
+  event_at     DateTime             @default(now())
+
+  user              User             @relation(fields: [user_id], references: [id], onDelete: Cascade)
+  processed_article ProcessedArticle @relation(fields: [p_article_id], references: [id], onDelete: Cascade)
+
+  @@map("article_view_event")
 }

--- a/server/src/routes/article.ts
+++ b/server/src/routes/article.ts
@@ -1,5 +1,6 @@
 import { Router } from 'express'
-import { getArticles, getArticleById } from '../controllers/articleController'
+import { getArticles, getArticleById, storeArticleViewEvent } from '../controllers/articleController'
+import { authenticateJWT } from '../middlewares/authenticateJWT'
 
 const router = Router()
 
@@ -14,5 +15,11 @@ router.get('/', getArticles)
  * GET /:id
  */
 router.get('/:id', getArticleById)
+
+/**
+ * 기사 조회 이벤트 저장
+ * POST /view-events
+ */
+router.post('/view-events', authenticateJWT, storeArticleViewEvent)
 
 export default router

--- a/server/src/services/__tests__/articleService.test.ts
+++ b/server/src/services/__tests__/articleService.test.ts
@@ -42,8 +42,6 @@ describe('ArticleService', () => {
 
     const mockArticle3: ProcessedArticle = {
       id: 3,
-      title: 'Test Article 3',
-      one_line_summary: 'Summary 3',
       full_summary: 'Full summary 3',
       language: 'ko',
       region: null,
@@ -286,6 +284,24 @@ describe('ArticleService', () => {
       }
 
       expect(prismaMock.processedArticle.findUnique).toHaveBeenCalledTimes(testIds.length)
+    })
+  })
+
+  describe('storeArticleViewEvent', () => {
+    it('Successfully stores an article view event', async () => {
+      const userId = 1
+      const articleId = 2
+      const eventType = 'VIEW'
+
+      await articleService.storeArticleViewEvent(userId, articleId, eventType)
+
+      expect(prismaMock.articleViewEvent.create).toHaveBeenCalledWith({
+        data: {
+          user_id: userId,
+          p_article_id: articleId,
+          event_type: eventType,
+        },
+      })
     })
   })
 

--- a/server/src/services/articleService.ts
+++ b/server/src/services/articleService.ts
@@ -1,4 +1,4 @@
-import { ProcessedArticle } from '@prisma/client'
+import { ArticleViewEventType, ProcessedArticle } from '@prisma/client'
 import { prisma } from '../../prisma/prisma'
 import { createCursor, decodeCursor } from '../utils/cursor'
 import dayjs from 'dayjs'
@@ -95,5 +95,26 @@ export const articleService = {
     }
 
     return article
+  },
+
+  /**
+   * 특정 기사에 대한 사용자 이벤트를 저장합니다.
+   * 이 함수는 사용자가 특정 기사에 대해 어떤 이벤트를 발생시켰는지 기록합니다.
+   * @param userId - 이벤트를 발생시킨 사용자의 ID
+   * @param articleId - 이벤트가 발생한 기사의 ID
+   * @param eventType - 발생한 이벤트의 유형 (예: 'VIEW', 'DETAIL_VIEW' 등)
+   * @return Promise<void> - 이벤트 저장이 완료되면 반환되는 프로미스
+   * @example
+   * // 사용자 1이 기사 2에 대해 조회 이벤트를 저장
+   * storeArticleViewEvent(1, 2, 'VIEW')
+   */
+  storeArticleViewEvent: async (userId: number, articleId: number, eventType: ArticleViewEventType): Promise<void> => {
+    await prisma.articleViewEvent.create({
+      data: {
+        user_id: userId,
+        p_article_id: articleId,
+        event_type: eventType,
+      },
+    })
   },
 }

--- a/server/src/swagger/openapi.yaml
+++ b/server/src/swagger/openapi.yaml
@@ -368,10 +368,67 @@ paths:
                     success: false
                     message: Internal server error
 
+  /articles/view-events:
+    post:
+      summary: 기사 조회 이벤트 저장
+      description: 사용자가 기사를 조회했을 때 이벤트를 저장합니다. 헤더에 JWT 토큰을 포함해야 합니다. 현재 eventType은 "VIEW" 또는 "DETAIL_VIEW"만 허용됩니다.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/StoreArticleViewEventRequest'
+
+      responses:
+        '200':
+          description: 이벤트 저장 성공
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SuccessResponse'
+              examples:
+                success:
+                  summary: 이벤트 저장 성공
+                  value:
+                    success: true
+                    data: null
+                    message: Article view event stored successfully
+
+        '400':
+          description: 잘못된 요청 (필수 필드 누락 등)
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                invalidRequest:
+                  summary: 필수 필드 누락
+                  value:
+                    success: false
+                    message: articleId and eventType are required
+                invalidEventType:
+                  summary: 잘못된 이벤트 타입
+                  value:
+                    success: false
+                    message: Invalid eventType
+
+        '500':
+          description: 서버 오류
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                serverError:
+                  summary: 서버 오류
+                  value:
+                    success: false
+                    message: Internal server error
+
   /users:
     patch:
       summary: 사용자 정보 업데이트
-      description: 사용자의 정보를 업데이트 합니다. 현재는 닉네임만 업데이트 가능합니다.
+      description: 사용자의 정보를 업데이트 합니다. 현재는 닉네임만 업데이트 가능합니다. 헤더에 JWT 토큰을 포함해야 합니다.
       requestBody:
         required: true
         content:
@@ -448,7 +505,7 @@ paths:
   /users/section-preferences:
     patch:
       summary: 사용자 섹션 선호도 업데이트
-      description: 사용자의 섹션 선호도를 업데이트합니다.
+      description: 사용자의 섹션 선호도를 업데이트합니다. 헤더에 JWT 토큰을 포함해야 합니다.
       requestBody:
         required: true
         content:
@@ -504,7 +561,7 @@ paths:
 
     get:
       summary: 사용자 섹션 선호도 조회
-      description: 사용자의 섹션 선호도를 조회합니다.
+      description: 사용자의 섹션 선호도를 조회합니다. 헤더에 JWT 토큰을 포함해야 합니다.
       responses:
         '200':
           description: 사용자 섹션 선호도 조회 성공
@@ -697,6 +754,18 @@ components:
           type: string
           description: 사용자 닉네임
           example: '새로운 닉네임'
+
+    StoreArticleViewEventRequest:
+      type: object
+      properties:
+        articleId:
+          type: integer
+          description: 조회한 기사 ID
+          example: 1
+        eventType:
+          type: string
+          description: 이벤트 타입 ("VIEW" or "DETAIL_VIEW")
+          example: 'VIEW'
 
     PhoneVerifySuccessResponse:
       type: object


### PR DESCRIPTION
# Changelog
- 사용자의 조회 이벤트를 기록하는 테이블 `ArticleViewEvent`을 생성하였습니다.
- 사용자의 조회 이벤트를 저장하는 API를 구현하고 `/api/articles/view-events` 에 매핑하였습니다.
- Swagger에 해당 API를 명세하였습니다.

# Testing
- API 요청 테스트
<img width="690" height="485" alt="image" src="https://github.com/user-attachments/assets/981e242a-2c36-4a52-9fcc-a9272066d91b" />
<img width="834" height="142" alt="image" src="https://github.com/user-attachments/assets/f901d3e8-7b97-48c3-9f97-13fde9009029" />

- 유닛테스트
<img width="858" height="952" alt="image" src="https://github.com/user-attachments/assets/dc2b68ac-aaaa-43cf-a903-633ac049eced" />

- Swagger 문서
<img width="1421" height="1012" alt="image" src="https://github.com/user-attachments/assets/470d39ff-6195-4d84-bb28-9a96fb2b69b3" />

# Ops Impact
N/A

# Version Compatibility
N/A