### PR TITLE
[Terraform] ProcessedArticle의 Embedding Vector를 BigQuery에 저장

### DIFF
--- a/terraform/apis.tf
+++ b/terraform/apis.tf
@@ -52,3 +52,8 @@ resource "google_project_service" "resource_manager" {
   project = var.project
   service = "cloudresourcemanager.googleapis.com"
 }
+
+resource "google_project_service" "bigquery" {
+  project = var.project
+  service = "bigquery.googleapis.com"
+}

--- a/terraform/bigquery.tf
+++ b/terraform/bigquery.tf
@@ -1,0 +1,33 @@
+resource "google_bigquery_dataset" "recommendation" {
+  project     = var.project
+  dataset_id  = "recommendation"
+  location    = var.region
+  description = "Dataset for article recommendations"
+}
+
+resource "google_bigquery_table" "p_article_embeddings" {
+  project             = var.project
+  dataset_id          = google_bigquery_dataset.recommendation.dataset_id
+  table_id            = "p_article_embeddings"
+  schema              = file("${path.module}/src/schema/p_article_embeddings.json")
+  deletion_protection = false
+
+  time_partitioning {
+    type  = "DAY"
+    field = "created_at"
+  }
+
+}
+
+resource "google_bigquery_table" "user_p_article_scores" {
+  project             = var.project
+  dataset_id          = google_bigquery_dataset.recommendation.dataset_id
+  table_id            = "user_p_article_scores"
+  schema              = file("${path.module}/src/schema/user_embeddings.json")
+  deletion_protection = false
+
+  time_partitioning {
+    type  = "DAY"
+    field = "updated_at"
+  }
+}

--- a/terraform/cluster_summarizer.tf
+++ b/terraform/cluster_summarizer.tf
@@ -16,11 +16,15 @@ module "cluster_summarizer" {
     INSTANCE_CONNECTION_NAME  = google_sql_database_instance.mysql.connection_name
     MYSQL_SUMMARIZER_USERNAME = data.google_secret_manager_secret_version.mysql_summarizer_username.secret_data
     MYSQL_SUMMARIZER_PASSWORD = data.google_secret_manager_secret_version.mysql_summarizer_password.secret_data
+    BQ_EMBEDDING_DATASET      = google_bigquery_dataset.recommendation.dataset_id
+    BQ_EMBEDDING_TABLE        = google_bigquery_table.p_article_embeddings.table_id
   }
   roles = [
     "roles/cloudsql.client",
     "roles/cloudsql.instanceUser",
     "roles/aiplatform.user",
     "roles/aiplatform.endpointUser",
+    "roles/bigquery.dataEditor",
+    "roles/bigquery.jobUser",
   ]
 }

--- a/terraform/src/cluster_summarizer/requirements.txt
+++ b/terraform/src/cluster_summarizer/requirements.txt
@@ -4,3 +4,4 @@ PyMySQL==1.1.1
 functions-framework==3.8.3
 google-cloud-logging==3.12.1
 pillow==11.2.1
+google-cloud-bigquery==3.32.0

--- a/terraform/src/schema/p_article_embeddings.json
+++ b/terraform/src/schema/p_article_embeddings.json
@@ -1,0 +1,22 @@
+[
+  {
+    "name": "p_article_id",
+    "type": "INT64",
+    "mode": "REQUIRED"
+  },
+  {
+    "name": "embedding_vector",
+    "type": "FLOAT64",
+    "mode": "REPEATED"
+  },
+  {
+    "name": "created_at",
+    "type": "TIMESTAMP",
+    "mode": "REQUIRED"
+  },
+  {
+    "name": "updated_at",
+    "type": "TIMESTAMP",
+    "mode": "REQUIRED"
+  }
+]

--- a/terraform/src/schema/user_embeddings.json
+++ b/terraform/src/schema/user_embeddings.json
@@ -1,0 +1,22 @@
+[
+  {
+    "name": "user_id",
+    "type": "INT64",
+    "mode": "REQUIRED"
+  },
+  {
+    "name": "embedding_vector",
+    "type": "FLOAT64",
+    "mode": "REPEATED"
+  },
+  {
+    "name": "created_at",
+    "type": "TIMESTAMP",
+    "mode": "REQUIRED"
+  },
+  {
+    "name": "updated_at",
+    "type": "TIMESTAMP",
+    "mode": "REQUIRED"
+  }
+]


### PR DESCRIPTION
# Changelog
- BigQuery
  - API를 활성화하고, 추천 알고리즘을 위한 데이터셋 `recommendation`을 생성하였습니다.
  - ProcessedArticle의 Embedding Vector를 저장하는 `p_article_embeddings`테이블을 생성하였습니다.
  - 사용자의 Embedding Vector를 저장하는 `user_embeddings`테이블을 생성하였습니다.
- Cluster Summarizer
  - BigQuery에 데이터를 저장하기 위해 BigQueryClient 클래스를 생성하였습니다.
  - VertexAI 클래스에 Embedding Vector를 계산하는 `get_embedding()`함수를 추가하였습니다.
  - ProcessedArticle이 Cloud SQL에 저장된 후 BigQuery에 Embedding Vector를 저장하도록 하였습니다.

# Testing
- Workflow 실행 결과
<img width="1415" height="1251" alt="image" src="https://github.com/user-attachments/assets/560f3771-7f2e-421b-a6c2-3d38447431d8" />


# Ops Impact
N/A

# Version Compatibility
N/A