### PR TITLE
[Terraform] 요약 시 Section ID를 상수로 지정

### DIFF
--- a/terraform/src/schema/p_article_embeddings.json
+++ b/terraform/src/schema/p_article_embeddings.json
@@ -5,6 +5,11 @@
     "mode": "REQUIRED"
   },
   {
+    "name": "section_id",
+    "type": "INT64",
+    "mode": "REQUIRED"
+  },
+  {
     "name": "embedding_vector",
     "type": "FLOAT64",
     "mode": "REPEATED"


### PR DESCRIPTION
# Changelog
- DB가 생성될 때 seed.ts에서 Section을 고정적으로 생성하고 있으므로, 굳이 동적으로 `section_id`를 지정할 필요가 없습니다. 오히려 동적으로  생성하면 `section_id` 불일치가 발생할 수 있습니다.
- `SECTION`이라는 전역변수에 현재 영역 정보를 저장하고, 동적으로 영역을 생성하는 로직을 제거하였습니다.
- AI 응답을 받을 때 `section_id`를 바로 전달받도록 변경하였습니다.
- BigQuery의 `p_article_embedding`에 `section_id`를 저장하였습니다.

# Testing
- BigQuery의 `p_article_embedding`에 `section_id` 확인
<img width="770" height="613" alt="image" src="https://github.com/user-attachments/assets/2173b00d-bca9-44e1-bc1e-625d3cc014a6" />

# Ops Impact
N/A

# Version Compatibility
N/A