### PR TITLE
[Terraform] 섹션별 평균 Embedding Vector 캐싱

### DIFF
--- a/terraform/apis.tf
+++ b/terraform/apis.tf
@@ -57,3 +57,8 @@ resource "google_project_service" "bigquery" {
   project = var.project
   service = "bigquery.googleapis.com"
 }
+
+resource "google_project_service" "bigquery_data_transfer" {
+  project = var.project
+  service = "bigquerydatatransfer.googleapis.com"
+}

--- a/terraform/bigquery.tf
+++ b/terraform/bigquery.tf
@@ -31,3 +31,77 @@ resource "google_bigquery_table" "user_embeddings" {
     field = "updated_at"
   }
 }
+
+resource "google_bigquery_table" "section_avg_embeddings" {
+  project             = var.project
+  dataset_id          = google_bigquery_dataset.recommendation.dataset_id
+  table_id            = "section_avg_embeddings"
+  schema              = file("${path.module}/src/schema/section_avg_embeddings.json")
+  deletion_protection = false
+}
+
+resource "google_service_account" "bq_data_transfer_service_account" {
+  account_id   = "bq-data-transfer-sa"
+  display_name = "BigQuery Data Transfer Service Account"
+  project      = var.project
+}
+
+resource "google_project_iam_member" "bq_data_transfer_service_account_role" {
+  project = var.project
+  role    = "roles/bigquery.dataEditor"
+  member  = google_service_account.bq_data_transfer_service_account.member
+}
+
+resource "google_project_iam_member" "bq_data_transfer_service_account_bigquery_user" {
+  project = var.project
+  role    = "roles/bigquery.user"
+  member  = google_service_account.bq_data_transfer_service_account.member
+}
+
+resource "google_bigquery_data_transfer_config" "section_avg_embeddings_update" {
+  project              = var.project
+  location             = var.region
+  display_name         = "Update Section Avg Embeddings"
+  data_source_id       = "scheduled_query"
+  service_account_name = google_service_account.bq_data_transfer_service_account.email
+
+  schedule = "every 24 hours"
+
+  destination_dataset_id = google_bigquery_dataset.recommendation.dataset_id
+  params = {
+    destination_table_name_template = google_bigquery_table.section_avg_embeddings.table_id
+    write_disposition               = "WRITE_TRUNCATE"
+
+    query = <<-SQL
+    WITH exploded AS (
+      SELECT
+        section_id,
+        OFFSET AS dim_idx,
+        dim_val
+      FROM (
+        SELECT
+          section_id,
+          embedding_vector
+        FROM `${google_bigquery_dataset.recommendation.dataset_id}.${google_bigquery_table.p_article_embeddings.table_id}`
+        QUALIFY ROW_NUMBER() OVER (
+          PARTITION BY section_id
+          ORDER BY updated_at DESC
+        ) <= 20 -- 섹션 ID별로 최신 20개의 임베딩 벡터만 사용
+      ), UNNEST(embedding_vector) AS dim_val WITH OFFSET
+    )
+    SELECT
+      section_id,
+      ARRAY_AGG(avg_dim ORDER BY dim_idx) AS avg_embedding_vector,
+      CURRENT_TIMESTAMP() AS updated_at
+    FROM (
+      SELECT
+        section_id,
+        dim_idx,
+        AVG(dim_val) AS avg_dim
+      FROM exploded
+      GROUP BY section_id, dim_idx
+    )
+    GROUP BY section_id;
+    SQL
+  }
+}

--- a/terraform/bigquery.tf
+++ b/terraform/bigquery.tf
@@ -1,3 +1,7 @@
+locals {
+  section_avg_embeddings_limit = 20
+}
+
 resource "google_bigquery_dataset" "recommendation" {
   project     = var.project
   dataset_id  = "recommendation"
@@ -86,7 +90,7 @@ resource "google_bigquery_data_transfer_config" "section_avg_embeddings_update" 
         QUALIFY ROW_NUMBER() OVER (
           PARTITION BY section_id
           ORDER BY updated_at DESC
-        ) <= 20 -- 섹션 ID별로 최신 20개의 임베딩 벡터만 사용
+        ) <= ${local.section_avg_embeddings_limit}
       ), UNNEST(embedding_vector) AS dim_val WITH OFFSET
     )
     SELECT

--- a/terraform/src/schema/section_avg_embeddings.json
+++ b/terraform/src/schema/section_avg_embeddings.json
@@ -1,0 +1,18 @@
+[
+  {
+    "name": "section_id",
+    "type": "INT64",
+    "mode": "REQUIRED"
+  },
+  {
+    "name": "avg_embedding_vector",
+    "type": "FLOAT64",
+    "mode": "REPEATED"
+  },
+  {
+    "name": "updated_at",
+    "type": "TIMESTAMP",
+    "mode": "REQUIRED",
+    "defaultValueExpression": "CURRENT_TIMESTAMP()"
+  }
+]


### PR DESCRIPTION
# Changelog
- `section_avg_embeddings` 테이블을 생성하여 섹션별 평균 임베딩을 저장하였습니다.
  - 이 테이블은 이후 사용자가 회원가입시 빠르게 사용자 임베딩을 계산하기 위해 설계되었습니다.
  - 사용자가 회원가입 시, 섹션별 평균 임베딩 벡터와 사용자의 섹션별 선호도를 곱하여 사용자 임베딩 벡터가 초기화됩니다.
- Scheduled Query `section_avg_embeddings_update`를 생성하여 24시간마다 섹션별 평균 임베딩을 계산하도록 하였습니다.

# Testing
- Scheduled Query 실행 결과
<img width="1323" height="262" alt="image" src="https://github.com/user-attachments/assets/0859a090-d006-4017-a8c8-790dc0d68e91" />

- `section_avg_embeddings` 테이블 데이터 확인
<img width="1030" height="921" alt="image" src="https://github.com/user-attachments/assets/ae7bb302-3f8c-4a68-8102-043e94282684" />

# Ops Impact
N/A

# Version Compatibility
N/A