### PR TITLE
[Terraform] 사용자 Embedding Vector 계산 시 캐싱 테이블 활용

### DIFF
--- a/terraform/src/schema/section_avg_embeddings.json
+++ b/terraform/src/schema/section_avg_embeddings.json
@@ -1,18 +1,18 @@
 [
   {
     "name": "section_id",
-    "type": "INT64",
+    "type": "INTEGER",
     "mode": "REQUIRED"
   },
   {
     "name": "avg_embedding_vector",
-    "type": "FLOAT64",
+    "type": "FLOAT",
     "mode": "REPEATED"
   },
   {
     "name": "updated_at",
     "type": "TIMESTAMP",
-    "mode": "REQUIRED",
+    "mode": "NULLABLE",
     "defaultValueExpression": "CURRENT_TIMESTAMP()"
   }
 ]

--- a/terraform/src/schema/section_avg_embeddings.json
+++ b/terraform/src/schema/section_avg_embeddings.json
@@ -12,7 +12,6 @@
   {
     "name": "updated_at",
     "type": "TIMESTAMP",
-    "mode": "NULLABLE",
-    "defaultValueExpression": "CURRENT_TIMESTAMP()"
+    "mode": "NULLABLE"
   }
 ]

--- a/terraform/user_embeddings.tf
+++ b/terraform/user_embeddings.tf
@@ -16,9 +16,10 @@ module "calculate_user_embeddings" {
     MYSQL_USERNAME           = data.google_secret_manager_secret_version.mysql_embedding_calculator_username.secret_data
     MYSQL_PASSWORD           = data.google_secret_manager_secret_version.mysql_embedding_calculator_password.secret_data
 
-    RECOMMENDATION_DATASET    = google_bigquery_dataset.recommendation.dataset_id
-    P_ARTICLE_EMBEDDING_TABLE = google_bigquery_table.p_article_embeddings.table_id
-    USER_EMBEDDING_TABLE      = google_bigquery_table.user_embeddings.table_id
+    RECOMMENDATION_DATASET       = google_bigquery_dataset.recommendation.dataset_id
+    P_ARTICLE_EMBEDDING_TABLE    = google_bigquery_table.p_article_embeddings.table_id
+    USER_EMBEDDING_TABLE         = google_bigquery_table.user_embeddings.table_id
+    SECTION_AVG_EMBEDDINGS_TABLE = google_bigquery_table.section_avg_embeddings.table_id
   }
 
   roles = [


### PR DESCRIPTION
# Changelog
- #75 에서 생성된 `section_avg_embeddings` 테이블을 활용하여 `calculate_user_embeddings` 함수에서 섹선별 평균 임베딩을 계산하는 로직을 제거하였습니다.

# Testing
- Cloud Function 실행 결과 ( 9명의 사용자 중 9명 정상적으로 생성됨)
<img width="871" height="209" alt="image" src="https://github.com/user-attachments/assets/fe0ee5fd-1b05-491b-b40a-6002a97d7042" />

<img width="430" height="360" alt="image" src="https://github.com/user-attachments/assets/fc2f216a-6e9f-4ae0-ad80-154a766d63f2" />

# Ops Impact
N/A

# Version Compatibility
N/A