### PR TITLE
[Server] 뉴스 좋아요 API 구현

### DIFF
--- a/server/src/controllers/__tests__/articleController.test.ts
+++ b/server/src/controllers/__tests__/articleController.test.ts
@@ -7,6 +7,7 @@ import {
 } from '../articleController'
 import { ArticleNotFoundError, articleService } from '../../services/articleService'
 import { successWithCursor, success, errors } from '../../utils/response'
+import { prismaMock } from '../../../prisma/mock'
 
 jest.mock('../../services/articleService')
 jest.mock('../../utils/response')
@@ -191,6 +192,7 @@ describe('articleController', () => {
     it('should add like to article and respond with success', async () => {
       req.userId = 1
       req.params.id = '42'
+      ;(articleService.getArticleById as jest.Mock).mockResolvedValue({ id: 42 })
 
       await addLikeToArticle(req as any, res as any)
 
@@ -203,6 +205,7 @@ describe('articleController', () => {
     it('should return unauthorized if userId is missing', async () => {
       req.userId = null
       req.params.id = '42'
+      ;(articleService.getArticleById as jest.Mock).mockResolvedValue({ id: 42 })
 
       await addLikeToArticle(req as any, res as any)
 
@@ -210,9 +213,23 @@ describe('articleController', () => {
       expect(mockSuccess).not.toHaveBeenCalled()
     })
 
+    it('should return not found if article does not exist', async () => {
+      req.userId = 1
+      req.params.id = '42'
+      ;(articleService.getArticleById as jest.Mock).mockRejectedValue(new ArticleNotFoundError('Article not found'))
+
+      await addLikeToArticle(req as any, res as any)
+
+      expect(mockSuccess).not.toHaveBeenCalled()
+      expect(errors.notFound).toHaveBeenCalledWith(res, 'Article not found')
+      expect(articleService.addLikeToArticle).not.toHaveBeenCalled()
+    })
+
     it('should respond with internal error on service exception', async () => {
       req.userId = 1
       req.params.id = '42'
+      ;(articleService.getArticleById as jest.Mock).mockResolvedValue({ id: 42 })
+
       const error = new Error('Service error')
       ;(articleService.addLikeToArticle as jest.Mock).mockRejectedValue(error)
 
@@ -228,6 +245,7 @@ describe('articleController', () => {
     it('should remove like from article and respond with success', async () => {
       req.userId = 1
       req.params.id = '42'
+      ;(articleService.getArticleById as jest.Mock).mockResolvedValue({ id: 42 })
 
       await removeLikeFromArticle(req as any, res as any)
 
@@ -240,6 +258,7 @@ describe('articleController', () => {
     it('should return unauthorized if userId is missing', async () => {
       req.userId = null
       req.params.id = '42'
+      ;(articleService.getArticleById as jest.Mock).mockResolvedValue({ id: 42 })
 
       await removeLikeFromArticle(req as any, res as any)
 
@@ -247,9 +266,23 @@ describe('articleController', () => {
       expect(mockSuccess).not.toHaveBeenCalled()
     })
 
+    it('should return not found if article does not exist', async () => {
+      req.userId = 1
+      req.params.id = '42'
+      ;(articleService.getArticleById as jest.Mock).mockRejectedValue(new ArticleNotFoundError('Article not found'))
+
+      await removeLikeFromArticle(req as any, res as any)
+
+      expect(mockSuccess).not.toHaveBeenCalled()
+      expect(errors.notFound).toHaveBeenCalledWith(res, 'Article not found')
+      expect(articleService.removeLikeFromArticle).not.toHaveBeenCalled()
+    })
+
     it('should respond with internal error on service exception', async () => {
       req.userId = 1
       req.params.id = '42'
+      ;(articleService.getArticleById as jest.Mock).mockResolvedValue({ id: 42 })
+
       const error = new Error('Service error')
       ;(articleService.removeLikeFromArticle as jest.Mock).mockRejectedValue(error)
 

--- a/server/src/controllers/__tests__/articleController.test.ts
+++ b/server/src/controllers/__tests__/articleController.test.ts
@@ -1,4 +1,10 @@
-import { getArticles, getArticleById, storeArticleViewEvent } from '../articleController'
+import {
+  getArticles,
+  getArticleById,
+  storeArticleViewEvent,
+  addLikeToArticle,
+  removeLikeFromArticle,
+} from '../articleController'
 import { ArticleNotFoundError, articleService } from '../../services/articleService'
 import { successWithCursor, success, errors } from '../../utils/response'
 
@@ -176,6 +182,80 @@ describe('articleController', () => {
       await storeArticleViewEvent(req as any, res as any)
 
       expect(consoleErrorSpy).toHaveBeenCalledWith('Error storing article view event:', error)
+      expect(mockInternalError).toHaveBeenCalledWith(res)
+      expect(mockSuccess).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('addLikeToArticle', () => {
+    it('should add like to article and respond with success', async () => {
+      req.userId = 1
+      req.params.id = '42'
+
+      await addLikeToArticle(req as any, res as any)
+
+      expect(articleService.addLikeToArticle).toHaveBeenCalledWith(1, 42)
+      expect(mockSuccess).toHaveBeenCalledWith(res, null, {
+        message: 'Like added to article successfully',
+      })
+    })
+
+    it('should return unauthorized if userId is missing', async () => {
+      req.userId = null
+      req.params.id = '42'
+
+      await addLikeToArticle(req as any, res as any)
+
+      expect(errors.unauthorized).toHaveBeenCalledWith(res, 'User ID is required')
+      expect(mockSuccess).not.toHaveBeenCalled()
+    })
+
+    it('should respond with internal error on service exception', async () => {
+      req.userId = 1
+      req.params.id = '42'
+      const error = new Error('Service error')
+      ;(articleService.addLikeToArticle as jest.Mock).mockRejectedValue(error)
+
+      await addLikeToArticle(req as any, res as any)
+
+      expect(consoleErrorSpy).toHaveBeenCalledWith('Error adding like to article:', error)
+      expect(mockInternalError).toHaveBeenCalledWith(res)
+      expect(mockSuccess).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('removeLikeFromArticle', () => {
+    it('should remove like from article and respond with success', async () => {
+      req.userId = 1
+      req.params.id = '42'
+
+      await removeLikeFromArticle(req as any, res as any)
+
+      expect(articleService.removeLikeFromArticle).toHaveBeenCalledWith(1, 42)
+      expect(mockSuccess).toHaveBeenCalledWith(res, null, {
+        message: 'Like removed from article successfully',
+      })
+    })
+
+    it('should return unauthorized if userId is missing', async () => {
+      req.userId = null
+      req.params.id = '42'
+
+      await removeLikeFromArticle(req as any, res as any)
+
+      expect(errors.unauthorized).toHaveBeenCalledWith(res, 'User ID is required')
+      expect(mockSuccess).not.toHaveBeenCalled()
+    })
+
+    it('should respond with internal error on service exception', async () => {
+      req.userId = 1
+      req.params.id = '42'
+      const error = new Error('Service error')
+      ;(articleService.removeLikeFromArticle as jest.Mock).mockRejectedValue(error)
+
+      await removeLikeFromArticle(req as any, res as any)
+
+      expect(consoleErrorSpy).toHaveBeenCalledWith('Error removing like from article:', error)
       expect(mockInternalError).toHaveBeenCalledWith(res)
       expect(mockSuccess).not.toHaveBeenCalled()
     })

--- a/server/src/controllers/articleController.ts
+++ b/server/src/controllers/articleController.ts
@@ -116,3 +116,67 @@ export const storeArticleViewEvent = async (req: AuthenticatedRequest, res: Resp
     return errors.internal(res)
   }
 }
+
+/**
+ * 특정 기사에 사용자가 좋아요를 추가하는 컨트롤러입니다.
+ * 사용자가 인증된 상태에서 특정 기사에 좋아요를 추가할 수 있습니다.
+ * @param {AuthenticatedRequest} req - 인증된 사용자 요청 객체. userId와 body에 articleId가 포함되어야 합니다.
+ * @param {Response} res - Express 응답 객체.
+ * @example
+ * // 요청 예시
+ * POST /api/articles/:id/like
+ */
+export const addLikeToArticle = async (req: AuthenticatedRequest, res: Response) => {
+  const userId = req.userId
+  if (!userId) {
+    return errors.unauthorized(res, 'User ID is required')
+  }
+
+  const articleId = parseInt(req.params.id, 10)
+
+  try {
+    const article = await articleService.getArticleById(articleId)
+    await articleService.addLikeToArticle(userId, article.id)
+    return success(res, null, {
+      message: 'Like added to article successfully',
+    })
+  } catch (error) {
+    if (error instanceof ArticleNotFoundError) {
+      return errors.notFound(res, 'Article not found')
+    }
+    console.error('Error adding like to article:', error)
+    return errors.internal(res)
+  }
+}
+
+/**
+ * 특정 기사에 사용자가 좋아요를 제거하는 컨트롤러입니다.
+ * 사용자가 인증된 상태에서 특정 기사에 좋아요를 제거할 수 있습니다.
+ * @param {AuthenticatedRequest} req - 인증된 사용자 요청 객체. userId와 body에 articleId가 포함되어야 합니다.
+ * @param {Response} res - Express 응답 객체.
+ * @example
+ * // 요청 예시
+ * DELETE /api/articles/:id/like
+ */
+export const removeLikeFromArticle = async (req: AuthenticatedRequest, res: Response) => {
+  const userId = req.userId
+  if (!userId) {
+    return errors.unauthorized(res, 'User ID is required')
+  }
+
+  const articleId = parseInt(req.params.id, 10)
+
+  try {
+    const article = await articleService.getArticleById(articleId)
+    await articleService.removeLikeFromArticle(userId, article.id)
+    return success(res, null, {
+      message: 'Like removed from article successfully',
+    })
+  } catch (error) {
+    if (error instanceof ArticleNotFoundError) {
+      return errors.notFound(res, 'Article not found')
+    }
+    console.error('Error removing like from article:', error)
+    return errors.internal(res)
+  }
+}

--- a/server/src/routes/article.ts
+++ b/server/src/routes/article.ts
@@ -1,5 +1,11 @@
 import { Router } from 'express'
-import { getArticles, getArticleById, storeArticleViewEvent } from '../controllers/articleController'
+import {
+  getArticles,
+  getArticleById,
+  storeArticleViewEvent,
+  addLikeToArticle,
+  removeLikeFromArticle,
+} from '../controllers/articleController'
 import { authenticateJWT } from '../middlewares/authenticateJWT'
 
 const router = Router()
@@ -15,6 +21,18 @@ router.get('/', getArticles)
  * GET /:id
  */
 router.get('/:id', getArticleById)
+
+/**
+ * 특정 기사에 좋아요 추가
+ * POST /:id/like
+ */
+router.post('/:id/like', authenticateJWT, addLikeToArticle)
+
+/**
+ * 특정 기사에 좋아요 제거
+ * DELETE /:id/like
+ */
+router.delete('/:id/like', authenticateJWT, removeLikeFromArticle)
 
 /**
  * 기사 조회 이벤트 저장

--- a/server/src/services/__tests__/articleService.test.ts
+++ b/server/src/services/__tests__/articleService.test.ts
@@ -324,4 +324,56 @@ describe('ArticleService', () => {
       expect(articleError.name).not.toBe(genericError.name)
     })
   })
+
+  describe('addLikeToArticle', () => {
+    it('Successfully adds a like to an article', async () => {
+      const userId = 1
+      const articleId = 2
+
+      await articleService.addLikeToArticle(userId, articleId)
+
+      expect(prismaMock.like.create).toHaveBeenCalledWith({
+        data: {
+          user_id: userId,
+          p_article_id: articleId,
+        },
+      })
+    })
+
+    it('Throws error when Prisma returns an error', async () => {
+      const userId = 1
+      const articleId = 2
+      const error = new Error('Database connection failed')
+      prismaMock.like.create.mockRejectedValue(error)
+
+      await expect(articleService.addLikeToArticle(userId, articleId)).rejects.toThrow('Database connection failed')
+    })
+  })
+
+  describe('removeLikeFromArticle', () => {
+    it('Successfully removes a like from an article', async () => {
+      const userId = 1
+      const articleId = 2
+
+      await articleService.removeLikeFromArticle(userId, articleId)
+
+      expect(prismaMock.like.deleteMany).toHaveBeenCalledWith({
+        where: {
+          user_id: userId,
+          p_article_id: articleId,
+        },
+      })
+    })
+
+    it('Throws error when Prisma returns an error', async () => {
+      const userId = 1
+      const articleId = 2
+      const error = new Error('Database connection failed')
+      prismaMock.like.deleteMany.mockRejectedValue(error)
+
+      await expect(articleService.removeLikeFromArticle(userId, articleId)).rejects.toThrow(
+        'Database connection failed',
+      )
+    })
+  })
 })

--- a/server/src/services/articleService.ts
+++ b/server/src/services/articleService.ts
@@ -117,4 +117,40 @@ export const articleService = {
       },
     })
   },
+
+  /**
+   * 특정 기사에 사용자가 좋아요를 추가합니다.
+   * @param userId - 좋아요를 추가할 사용자의 ID
+   * @param articleId - 좋아요를 추가할 기사의 ID
+   * @return Promise<void> - 좋아요 추가가 완료되면 반환되는 프로미스
+   * @example
+   * // 사용자 1이 기사 2에 좋아요를 추가
+   * addLikeToArticle(1, 2)
+   */
+  addLikeToArticle: async (userId: number, articleId: number): Promise<void> => {
+    await prisma.like.create({
+      data: {
+        user_id: userId,
+        p_article_id: articleId,
+      },
+    })
+  },
+
+  /**
+   * 특정 기사에 사용자가 좋아요를 제거합니다.
+   * @param userId - 좋아요를 제거할 사용자의 ID
+   * @param articleId - 좋아요를 제거할 기사의 ID
+   * @return Promise<void> - 좋아요 제거가 완료되면 반환되는 프로미스
+   * @example
+   * // 사용자 1이 기사 2에 좋아요를 제거
+   * removeLikeFromArticle(1, 2)
+   */
+  removeLikeFromArticle: async (userId: number, articleId: number): Promise<void> => {
+    await prisma.like.deleteMany({
+      where: {
+        user_id: userId,
+        p_article_id: articleId,
+      },
+    })
+  },
 }

--- a/server/src/swagger/openapi.yaml
+++ b/server/src/swagger/openapi.yaml
@@ -368,6 +368,135 @@ paths:
                     success: false
                     message: Internal server error
 
+  /articles/{id}/like:
+    post:
+      summary: 기사 좋아요
+      description: 사용자가 특정 기사를 좋아요합니다. 헤더에 JWT 토큰을 포함해야 합니다.
+      parameters:
+        - in: path
+          name: id
+          schema:
+            type: integer
+          required: true
+          description: 기사 ID
+      responses:
+        '200':
+          description: 좋아요 성공
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SuccessResponse'
+              examples:
+                success:
+                  summary: 좋아요 성공
+                  value:
+                    success: true
+                    data: null
+                    message: Like added to article successfully
+
+        '401':
+          description: 인증 실패 (토큰이 없거나 유효하지 않음)
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                unauthorized:
+                  summary: 인증 실패
+                  value:
+                    success: false
+                    message: User ID is required
+
+        '404':
+          description: 기사 없음
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                articleNotFound:
+                  summary: 기사를 찾을 수 없음
+                  value:
+                    success: false
+                    message: Article not found
+
+        '500':
+          description: 서버 오류
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                serverError:
+                  summary: 서버 오류
+                  value:
+                    success: false
+                    message: Internal server error
+
+    delete:
+      summary: 기사 좋아요 취소
+      description: 사용자가 특정 기사의 좋아요를 취소합니다. 헤더에 JWT 토큰을 포함해야 합니다.
+      parameters:
+        - in: path
+          name: id
+          schema:
+            type: integer
+          required: true
+          description: 기사 ID
+      responses:
+        '200':
+          description: 좋아요 취소 성공
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SuccessResponse'
+              examples:
+                success:
+                  summary: 좋아요 취소 성공
+                  value:
+                    success: true
+                    data: null
+                    message: Like removed from article successfully
+
+        '401':
+          description: 인증 실패 (토큰이 없거나 유효하지 않음)
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                unauthorized:
+                  summary: 인증 실패
+                  value:
+                    success: false
+                    message: User ID is required
+
+        '404':
+          description: 기사 없음
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                articleNotFound:
+                  summary: 기사를 찾을 수 없음
+                  value:
+                    success: false
+                    message: Article not found
+
+        '500':
+          description: 서버 오류
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                serverError:
+                  summary: 서버 오류
+                  value:
+                    success: false
+                    message: Internal server error
+
   /articles/view-events:
     post:
       summary: 기사 조회 이벤트 저장


### PR DESCRIPTION
# Changelog
- 다음의 API를 구현하였습니다.
  - `POST /api/articles/:id/like`: 좋아요 요청
  - `DELETE /api/articles/:id/like`: 좋아요 취소

# Testing
- 좋아요 요청
<img width="656" height="396" alt="image" src="https://github.com/user-attachments/assets/25648d99-7bfe-498a-9d57-cb2b796a6346" />

- 좋아요 취소 요청
<img width="655" height="386" alt="image" src="https://github.com/user-attachments/assets/ea0d8a8a-73ee-480a-8e78-fbd954b3f344" />

- 유닛테스트
<img width="1086" height="1187" alt="image" src="https://github.com/user-attachments/assets/e0575097-64ae-4a15-aaa7-d0d25f04dc44" />


# Ops Impact
N/A

# Version Compatibility
N/A