### PR TITLE
[Server] 뉴스 스크랩 API 구현

### DIFF
--- a/server/src/controllers/__tests__/articleController.test.ts
+++ b/server/src/controllers/__tests__/articleController.test.ts
@@ -4,6 +4,8 @@ import {
   storeArticleViewEvent,
   addLikeToArticle,
   removeLikeFromArticle,
+  scrapArticle,
+  unscrapArticle,
 } from '../articleController'
 import { ArticleNotFoundError, articleService } from '../../services/articleService'
 import { successWithCursor, success, errors } from '../../utils/response'
@@ -289,6 +291,112 @@ describe('articleController', () => {
       await removeLikeFromArticle(req as any, res as any)
 
       expect(consoleErrorSpy).toHaveBeenCalledWith('Error removing like from article:', error)
+      expect(mockInternalError).toHaveBeenCalledWith(res)
+      expect(mockSuccess).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('scrapArticle', () => {
+    it('should scrap article and respond with success', async () => {
+      req.userId = 1
+      req.params.id = '42'
+      ;(articleService.getArticleById as jest.Mock).mockResolvedValue({ id: 42 })
+
+      await scrapArticle(req as any, res as any)
+
+      expect(articleService.scrapArticle).toHaveBeenCalledWith(1, 42)
+      expect(mockSuccess).toHaveBeenCalledWith(res, null, {
+        message: 'Article scrapped successfully',
+      })
+    })
+
+    it('should return unauthorized if userId is missing', async () => {
+      req.userId = null
+      req.params.id = '42'
+      ;(articleService.getArticleById as jest.Mock).mockResolvedValue({ id: 42 })
+
+      await scrapArticle(req as any, res as any)
+
+      expect(errors.unauthorized).toHaveBeenCalledWith(res, 'User ID is required')
+      expect(mockSuccess).not.toHaveBeenCalled()
+    })
+
+    it('should return not found if article does not exist', async () => {
+      req.userId = 1
+      req.params.id = '42'
+      ;(articleService.getArticleById as jest.Mock).mockRejectedValue(new ArticleNotFoundError('Article not found'))
+
+      await scrapArticle(req as any, res as any)
+
+      expect(mockSuccess).not.toHaveBeenCalled()
+      expect(errors.notFound).toHaveBeenCalledWith(res, 'Article not found')
+      expect(articleService.scrapArticle).not.toHaveBeenCalled()
+    })
+
+    it('should respond with internal error on service exception', async () => {
+      req.userId = 1
+      req.params.id = '42'
+      ;(articleService.getArticleById as jest.Mock).mockResolvedValue({ id: 42 })
+
+      const error = new Error('Service error')
+      ;(articleService.scrapArticle as jest.Mock).mockRejectedValue(error)
+
+      await scrapArticle(req as any, res as any)
+
+      expect(consoleErrorSpy).toHaveBeenCalledWith('Error scrapping article:', error)
+      expect(mockInternalError).toHaveBeenCalledWith(res)
+      expect(mockSuccess).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('unscrapArticle', () => {
+    it('should unscrap article and respond with success', async () => {
+      req.userId = 1
+      req.params.id = '42'
+      ;(articleService.getArticleById as jest.Mock).mockResolvedValue({ id: 42 })
+
+      await unscrapArticle(req as any, res as any)
+
+      expect(articleService.unscrapArticle).toHaveBeenCalledWith(1, 42)
+      expect(mockSuccess).toHaveBeenCalledWith(res, null, {
+        message: 'Article unscrapped successfully',
+      })
+    })
+
+    it('should return unauthorized if userId is missing', async () => {
+      req.userId = null
+      req.params.id = '42'
+      ;(articleService.getArticleById as jest.Mock).mockResolvedValue({ id: 42 })
+
+      await unscrapArticle(req as any, res as any)
+
+      expect(errors.unauthorized).toHaveBeenCalledWith(res, 'User ID is required')
+      expect(mockSuccess).not.toHaveBeenCalled()
+    })
+
+    it('should return not found if article does not exist', async () => {
+      req.userId = 1
+      req.params.id = '42'
+      ;(articleService.getArticleById as jest.Mock).mockRejectedValue(new ArticleNotFoundError('Article not found'))
+
+      await unscrapArticle(req as any, res as any)
+
+      expect(mockSuccess).not.toHaveBeenCalled()
+      expect(errors.notFound).toHaveBeenCalledWith(res, 'Article not found')
+      expect(articleService.unscrapArticle).not.toHaveBeenCalled()
+    })
+
+    it('should respond with internal error on service exception', async () => {
+      req.userId = 1
+      req.params.id = '42'
+      ;(articleService.getArticleById as jest.Mock).mockResolvedValue({ id: 42 })
+
+      const error = new Error('Service error')
+      ;(articleService.unscrapArticle as jest.Mock).mockRejectedValue(error)
+
+      await unscrapArticle(req as any, res as any)
+
+      expect(consoleErrorSpy).toHaveBeenCalledWith('Error unscrapping article:', error)
       expect(mockInternalError).toHaveBeenCalledWith(res)
       expect(mockSuccess).not.toHaveBeenCalled()
     })

--- a/server/src/controllers/articleController.ts
+++ b/server/src/controllers/articleController.ts
@@ -180,3 +180,67 @@ export const removeLikeFromArticle = async (req: AuthenticatedRequest, res: Resp
     return errors.internal(res)
   }
 }
+
+/**
+ * 특정 기사를 스크랩하는 컨트롤러입니다.
+ * 사용자가 인증된 상태에서 특정 기사를 스크랩할 수 있습니다.
+ * @param {AuthenticatedRequest} req - 인증된 사용자 요청 객체. userId와 body에 articleId가 포함되어야 합니다.
+ * @param {Response} res - Express 응답 객체.
+ * @example
+ * // 요청 예시
+ * POST /api/articles/:id/scrap
+ */
+export const scrapArticle = async (req: AuthenticatedRequest, res: Response) => {
+  const userId = req.userId
+  if (!userId) {
+    return errors.unauthorized(res, 'User ID is required')
+  }
+
+  const articleId = parseInt(req.params.id, 10)
+
+  try {
+    const article = await articleService.getArticleById(articleId)
+    await articleService.scrapArticle(userId, article.id)
+    return success(res, null, {
+      message: 'Article scrapped successfully',
+    })
+  } catch (error) {
+    if (error instanceof ArticleNotFoundError) {
+      return errors.notFound(res, 'Article not found')
+    }
+    console.error('Error scrapping article:', error)
+    return errors.internal(res)
+  }
+}
+
+/**
+ * 특정 기사에 대한 사용자의 스크랩을 제거하는 컨트롤러입니다.
+ * 사용자가 인증된 상태에서 특정 기사에 대한 스크랩을 제거할 수 있습니다
+ * @param {AuthenticatedRequest} req - 인증된 사용자 요청 객체. userId와 body에 articleId가 포함되어야 합니다.
+ * @Response} res - Express 응답 객체.
+ * @example
+ * // 요청 예시
+ * DELETE /api/articles/:id/scrap
+ */
+export const unscrapArticle = async (req: AuthenticatedRequest, res: Response) => {
+  const userId = req.userId
+  if (!userId) {
+    return errors.unauthorized(res, 'User ID is required')
+  }
+
+  const articleId = parseInt(req.params.id, 10)
+
+  try {
+    const article = await articleService.getArticleById(articleId)
+    await articleService.unscrapArticle(userId, article.id)
+    return success(res, null, {
+      message: 'Article unscrapped successfully',
+    })
+  } catch (error) {
+    if (error instanceof ArticleNotFoundError) {
+      return errors.notFound(res, 'Article not found')
+    }
+    console.error('Error unscrapping article:', error)
+    return errors.internal(res)
+  }
+}

--- a/server/src/routes/article.ts
+++ b/server/src/routes/article.ts
@@ -5,6 +5,8 @@ import {
   storeArticleViewEvent,
   addLikeToArticle,
   removeLikeFromArticle,
+  scrapArticle,
+  unscrapArticle,
 } from '../controllers/articleController'
 import { authenticateJWT } from '../middlewares/authenticateJWT'
 
@@ -33,6 +35,18 @@ router.post('/:id/like', authenticateJWT, addLikeToArticle)
  * DELETE /:id/like
  */
 router.delete('/:id/like', authenticateJWT, removeLikeFromArticle)
+
+/**
+ * 특정 기사 스크랩
+ * POST /:id/scrap
+ */
+router.post('/:id/scrap', authenticateJWT, scrapArticle)
+
+/**
+ * 특정 기사 스크랩 제거
+ * DELETE /:id/scrap
+ */
+router.delete('/:id/scrap', authenticateJWT, unscrapArticle)
 
 /**
  * 기사 조회 이벤트 저장

--- a/server/src/services/__tests__/articleService.test.ts
+++ b/server/src/services/__tests__/articleService.test.ts
@@ -376,4 +376,54 @@ describe('ArticleService', () => {
       )
     })
   })
+
+  describe('scrapArticle', () => {
+    it('Successfully scraps an article', async () => {
+      const userId = 1
+      const articleId = 2
+
+      await articleService.scrapArticle(userId, articleId)
+
+      expect(prismaMock.scrap.create).toHaveBeenCalledWith({
+        data: {
+          user_id: userId,
+          p_article_id: articleId,
+        },
+      })
+    })
+
+    it('Throws error when Prisma returns an error', async () => {
+      const userId = 1
+      const articleId = 2
+      const error = new Error('Database connection failed')
+      prismaMock.scrap.create.mockRejectedValue(error)
+
+      await expect(articleService.scrapArticle(userId, articleId)).rejects.toThrow('Database connection failed')
+    })
+  })
+
+  describe('unscrapArticle', () => {
+    it('Successfully removes a scrap from an article', async () => {
+      const userId = 1
+      const articleId = 2
+
+      await articleService.unscrapArticle(userId, articleId)
+
+      expect(prismaMock.scrap.deleteMany).toHaveBeenCalledWith({
+        where: {
+          user_id: userId,
+          p_article_id: articleId,
+        },
+      })
+    })
+
+    it('Throws error when Prisma returns an error', async () => {
+      const userId = 1
+      const articleId = 2
+      const error = new Error('Database connection failed')
+      prismaMock.scrap.deleteMany.mockRejectedValue(error)
+
+      await expect(articleService.unscrapArticle(userId, articleId)).rejects.toThrow('Database connection failed')
+    })
+  })
 })

--- a/server/src/services/articleService.ts
+++ b/server/src/services/articleService.ts
@@ -153,4 +153,40 @@ export const articleService = {
       },
     })
   },
+
+  /**
+   * 특정 기사에 사용자가 스크랩을 추가합니다.
+   * @param userId - 스크랩을 추가할 사용자의 ID
+   * @param articleId - 스크랩을 추가할 기사의 ID
+   * @return Promise<void> - 스크랩 추가가 완료되면 반환되는 프로미스
+   * @example
+   * // 사용자 1이 기사 2를 스크랩
+   * scrapArticle(1, 2)
+   */
+  scrapArticle: async (userId: number, articleId: number): Promise<void> => {
+    await prisma.scrap.create({
+      data: {
+        user_id: userId,
+        p_article_id: articleId,
+      },
+    })
+  },
+
+  /**
+   * 특정 기사에 대한 사용자의 스크랩을 제거합니다.
+   * @param userId - 스크랩을 제거할 사용자의 ID
+   * @param articleId - 스크랩을 제거할 기사의 ID
+   * @return Promise<void> - 스크랩 제거가 완료되면 반환되는 프로미스
+   * @example
+   * // 사용자 1이 기사 2의 스크랩을 제거
+   * unscrapArticle(1, 2)
+   */
+  unscrapArticle: async (userId: number, articleId: number): Promise<void> => {
+    await prisma.scrap.deleteMany({
+      where: {
+        user_id: userId,
+        p_article_id: articleId,
+      },
+    })
+  },
 }

--- a/server/src/swagger/openapi.yaml
+++ b/server/src/swagger/openapi.yaml
@@ -497,6 +497,135 @@ paths:
                     success: false
                     message: Internal server error
 
+  /articles/{id}/scrap:
+    post:
+      summary: 기사 스크랩
+      description: 사용자가 특정 기사를 스크랩합니다. 헤더에 JWT 토큰을 포함해야 합니다.
+      parameters:
+        - in: path
+          name: id
+          schema:
+            type: integer
+          required: true
+          description: 기사 ID
+      responses:
+        '200':
+          description: 스크랩 성공
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SuccessResponse'
+              examples:
+                success:
+                  summary: 스크랩 성공
+                  value:
+                    success: true
+                    data: null
+                    message: Article scrapped successfully
+
+        '401':
+          description: 인증 실패 (토큰이 없거나 유효하지 않음)
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                unauthorized:
+                  summary: 인증 실패
+                  value:
+                    success: false
+                    message: User ID is required
+
+        '404':
+          description: 기사 없음
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                articleNotFound:
+                  summary: 기사를 찾을 수 없음
+                  value:
+                    success: false
+                    message: Article not found
+
+        '500':
+          description: 서버 오류
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                serverError:
+                  summary: 서버 오류
+                  value:
+                    success: false
+                    message: Internal server error
+
+    delete:
+      summary: 기사 스크랩 취소
+      description: 사용자가 특정 기사의 스크랩을 취소합니다. 헤더에 JWT 토큰을 포함해야 합니다.
+      parameters:
+        - in: path
+          name: id
+          schema:
+            type: integer
+          required: true
+          description: 기사 ID
+      responses:
+        '200':
+          description: 스크랩 취소 성공
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SuccessResponse'
+              examples:
+                success:
+                  summary: 스크랩 취소 성공
+                  value:
+                    success: true
+                    data: null
+                    message: Article scrap removed successfully
+
+        '401':
+          description: 인증 실패 (토큰이 없거나 유효하지 않음)
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                unauthorized:
+                  summary: 인증 실패
+                  value:
+                    success: false
+                    message: User ID is required
+
+        '404':
+          description: 기사 없음
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                articleNotFound:
+                  summary: 기사를 찾을 수 없음
+                  value:
+                    success: false
+                    message: Article not found
+
+        '500':
+          description: 서버 오류
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                serverError:
+                  summary: 서버 오류
+                  value:
+                    success: false
+                    message: Internal server error
+
   /articles/view-events:
     post:
       summary: 기사 조회 이벤트 저장


### PR DESCRIPTION
# Changelog
- 뉴스 스크랩 API를 구현하였습니다.
  - `POST /articles/:id/scrap`: 특정 기사 스크랩
  - `DELETE /articles/:id/unscrap`: 특정 기사 스크랩 취소

# Testing
- 유닛테스트
<img width="852" height="1175" alt="image" src="https://github.com/user-attachments/assets/a580dae3-0b6c-4c68-8848-8ebaa15f05d8" />

- 스크랩 요청 결과
<img width="659" height="391" alt="image" src="https://github.com/user-attachments/assets/8a854ae8-c739-49de-8864-a4c34561520d" />

- DB 확인
<img width="593" height="96" alt="image" src="https://github.com/user-attachments/assets/23323c22-f753-4440-98c0-8ccfde7138fc" />

# Ops Impact
N/A

# Version Compatibility
N/A