### PR TITLE
[Server] View Event 저장 API 리팩토링

### DIFF
--- a/server/src/controllers/__tests__/articleController.test.ts
+++ b/server/src/controllers/__tests__/articleController.test.ts
@@ -136,7 +136,8 @@ describe('articleController', () => {
   describe('storeArticleViewEvent', () => {
     it('should store article view event and respond with success', async () => {
       req.userId = 1
-      req.body = { articleId: 123, eventType: 'VIEW' }
+      req.params.id = '123'
+      req.body = { eventType: 'VIEW' }
 
       await storeArticleViewEvent(req as any, res as any)
 
@@ -148,7 +149,8 @@ describe('articleController', () => {
 
     it('should return unauthorized if userId is missing', async () => {
       req.userId = null
-      req.body = { articleId: 123, eventType: 'VIEW' }
+      req.params.id = '123'
+      req.body = { eventType: 'VIEW' }
 
       await storeArticleViewEvent(req as any, res as any)
 
@@ -156,19 +158,21 @@ describe('articleController', () => {
       expect(mockSuccess).not.toHaveBeenCalled()
     })
 
-    it('should return bad request if articleId or eventType is missing', async () => {
+    it('should return bad request if eventType is missing', async () => {
       req.userId = 1
-      req.body = { articleId: null, eventType: 'VIEW' }
+      req.params.id = '123'
+      req.body = {}
 
       await storeArticleViewEvent(req as any, res as any)
 
-      expect(errors.badRequest).toHaveBeenCalledWith(res, 'articleId and eventType are required')
+      expect(errors.badRequest).toHaveBeenCalledWith(res, 'eventType is required')
       expect(mockSuccess).not.toHaveBeenCalled()
     })
 
     it('should return bad request if eventType is invalid', async () => {
       req.userId = 1
-      req.body = { articleId: 123, eventType: 'INVALID_EVENT' }
+      req.params.id = '123'
+      req.body = { eventType: 'INVALID_EVENT' }
 
       await storeArticleViewEvent(req as any, res as any)
 
@@ -178,7 +182,8 @@ describe('articleController', () => {
 
     it('should respond with internal error on service exception', async () => {
       req.userId = 1
-      req.body = { articleId: 123, eventType: 'VIEW' }
+      req.params.id = '123'
+      req.body = { eventType: 'VIEW' }
       const error = new Error('Service error')
       ;(articleService.storeArticleViewEvent as jest.Mock).mockRejectedValue(error)
 

--- a/server/src/controllers/articleController.ts
+++ b/server/src/controllers/articleController.ts
@@ -97,9 +97,11 @@ export const storeArticleViewEvent = async (req: AuthenticatedRequest, res: Resp
     return errors.unauthorized(res, 'User ID is required')
   }
 
-  const { articleId, eventType } = req.body
-  if (!articleId || !eventType) {
-    return errors.badRequest(res, 'articleId and eventType are required')
+  const articleId = parseInt(req.params.id, 10)
+
+  const { eventType } = req.body
+  if (!eventType) {
+    return errors.badRequest(res, 'eventType is required')
   }
 
   if (!Object.values(ArticleViewEventType).includes(eventType)) {

--- a/server/src/routes/article.ts
+++ b/server/src/routes/article.ts
@@ -52,6 +52,6 @@ router.delete('/:id/scrap', authenticateJWT, unscrapArticle)
  * 기사 조회 이벤트 저장
  * POST /view-events
  */
-router.post('/view-events', authenticateJWT, storeArticleViewEvent)
+router.post('/:id/view-events', authenticateJWT, storeArticleViewEvent)
 
 export default router

--- a/server/src/swagger/openapi.yaml
+++ b/server/src/swagger/openapi.yaml
@@ -626,17 +626,23 @@ paths:
                     success: false
                     message: Internal server error
 
-  /articles/view-events:
+  /articles/{id}/view-events:
     post:
       summary: 기사 조회 이벤트 저장
-      description: 사용자가 기사를 조회했을 때 이벤트를 저장합니다. 헤더에 JWT 토큰을 포함해야 합니다. 현재 eventType은 "VIEW" 또는 "DETAIL_VIEW"만 허용됩니다.
+      description: 사용자가 특정 기사를 조회했을 때 이벤트를 저장합니다. 헤더에 JWT 토큰을 포함해야 합니다.
+      parameters:
+        - in: path
+          name: id
+          schema:
+            type: integer
+          required: true
+          description: 기사 ID
       requestBody:
         required: true
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/StoreArticleViewEventRequest'
-
       responses:
         '200':
           description: 이벤트 저장 성공
@@ -653,22 +659,48 @@ paths:
                     message: Article view event stored successfully
 
         '400':
-          description: 잘못된 요청 (필수 필드 누락 등)
+          description: 잘못된 요청 (필드 타입 오류 등)
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
               examples:
-                invalidRequest:
-                  summary: 필수 필드 누락
+                missingEventType:
+                  summary: 이벤트 타입 누락
                   value:
                     success: false
-                    message: articleId and eventType are required
+                    message: eventType is required
                 invalidEventType:
                   summary: 잘못된 이벤트 타입
                   value:
                     success: false
                     message: Invalid eventType
+
+        '401':
+          description: 인증 실패 (토큰이 없거나 유효하지 않음)
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                unauthorized:
+                  summary: 인증 실패
+                  value:
+                    success: false
+                    message: User ID is required
+
+        '404':
+          description: 기사 없음
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                articleNotFound:
+                  summary: 기사를 찾을 수 없음
+                  value:
+                    success: false
+                    message: Article not found
 
         '500':
           description: 서버 오류
@@ -682,7 +714,6 @@ paths:
                   value:
                     success: false
                     message: Internal server error
-
   /users:
     patch:
       summary: 사용자 정보 업데이트
@@ -1016,10 +1047,6 @@ components:
     StoreArticleViewEventRequest:
       type: object
       properties:
-        articleId:
-          type: integer
-          description: 조회한 기사 ID
-          example: 1
         eventType:
           type: string
           description: 이벤트 타입 ("VIEW" or "DETAIL_VIEW")


### PR DESCRIPTION
# Changelog
- View Event를 저장하는 API의 엔드포인트를 다음과 같이 변경했습니다.
  - `POST /articles/view-events` -> `POST /articles/:id/view-events`
  - 뉴스 ID를 parameter로 전달받도록 수정하였습니다.

# Testing
- Swagger Documentaiton
<img width="1439" height="563" alt="image" src="https://github.com/user-attachments/assets/3488c6b0-9f5e-4bea-a1ca-935959da946a" />

- 유닛테스트
<img width="725" height="1161" alt="image" src="https://github.com/user-attachments/assets/5f266654-59ac-404c-8691-37691ec44b25" />

# Ops Impact
N/A

# Version Compatibility
N/A