### PR TITLE
[Server] 마이페이지 API 구현

### DIFF
--- a/server/src/controllers/__tests__/userController.test.ts
+++ b/server/src/controllers/__tests__/userController.test.ts
@@ -353,7 +353,7 @@ describe('getMyPageStats', () => {
 
     ;(userService.findUserById as jest.Mock).mockResolvedValue(user)
     ;(sectionService.getUserSectionStats as jest.Mock).mockResolvedValue(sectionStats)
-    ;(keywordService.getKeywordstats as jest.Mock).mockResolvedValue(keywordStats)
+    ;(keywordService.getUserKeywordStats as jest.Mock).mockResolvedValue(keywordStats)
 
     const res = mockRes()
 
@@ -361,7 +361,7 @@ describe('getMyPageStats', () => {
 
     expect(userService.findUserById).toHaveBeenCalledWith(userId)
     expect(sectionService.getUserSectionStats).toHaveBeenCalledWith(userId)
-    expect(keywordService.getKeywordstats).toHaveBeenCalledWith(userId)
+    expect(keywordService.getUserKeywordStats).toHaveBeenCalledWith(userId)
     expect(success).toHaveBeenCalledWith(
       res,
       { user, sectionStats, keywordStats },

--- a/server/src/controllers/userController.ts
+++ b/server/src/controllers/userController.ts
@@ -4,6 +4,7 @@ import { errors, success } from '../utils/response'
 import { AuthenticatedRequest } from '../middlewares/authenticateJWT'
 import { UserNotFoundError, userService } from '../services/userService'
 import { sectionService } from '../services/sectionService'
+import { keywordService } from '../services/keywordService'
 
 /**
  * 사용자의 닉네임을 업데이트하는 컨트롤러입니다.
@@ -168,6 +169,40 @@ export const getUserSectionPreferences = async (req: AuthenticatedRequest, res: 
     })
   } catch (error) {
     console.error('Error retrieving user section preferences:', error)
+    return errors.internal(res)
+  }
+}
+
+/**
+ * 사용자의 통계 정보를 조회하는 컨트롤러입니다.
+ * 사용자가 인증된 상태에서 자신의 통계 정보를 조회할 수 있습니다.
+ * @param {AuthenticatedRequest} req - 인증된 사용자 요청 객체. userId가 포함되어야 합니다.
+ * @param {Response} res - Express 응답 객체.
+ * @example
+ * // 요청 예시
+ * GET /api/users/stats
+ * @returns {Promise<Response>} 사용자의 통계 정보를 포함한 응답 객체
+ */
+export const getMyPageStats = async (req: AuthenticatedRequest, res: Response): Promise<Response> => {
+  const userId = req.userId
+  if (!userId) {
+    return errors.unauthorized(res, 'User ID is required')
+  }
+
+  try {
+    const user = await userService.findUserById(userId)
+    const sectionStats = await sectionService.getUserSectionStats(userId)
+    const keywordStats = await keywordService.getKeywordstats(userId)
+
+    return success(
+      res,
+      { user, sectionStats, keywordStats },
+      {
+        message: 'User stats retrieved successfully',
+      },
+    )
+  } catch (error) {
+    console.error('Error retrieving user stats:', error)
     return errors.internal(res)
   }
 }

--- a/server/src/controllers/userController.ts
+++ b/server/src/controllers/userController.ts
@@ -192,7 +192,7 @@ export const getMyPageStats = async (req: AuthenticatedRequest, res: Response): 
   try {
     const user = await userService.findUserById(userId)
     const sectionStats = await sectionService.getUserSectionStats(userId)
-    const keywordStats = await keywordService.getKeywordstats(userId)
+    const keywordStats = await keywordService.getUserKeywordStats(userId)
 
     return success(
       res,

--- a/server/src/routes/user.ts
+++ b/server/src/routes/user.ts
@@ -1,6 +1,11 @@
 import { Router } from 'express'
 import { authenticateJWT } from '../middlewares/authenticateJWT'
-import { getUserSectionPreferences, updateUser, updateUserSectionPreferences } from '../controllers/userController'
+import {
+  getMyPageStats,
+  getUserSectionPreferences,
+  updateUser,
+  updateUserSectionPreferences,
+} from '../controllers/userController'
 
 const router = Router()
 
@@ -18,5 +23,10 @@ router.patch('/section-preferences', authenticateJWT, updateUserSectionPreferenc
  * 사용자 섹션 선호도 조회
  */
 router.get('/section-preferences', authenticateJWT, getUserSectionPreferences)
+
+/**
+ * 마이페이지 통계 조회
+ */
+router.get('/mypage-stats', authenticateJWT, getMyPageStats)
 
 export default router

--- a/server/src/services/__tests__/keywordService.test.ts
+++ b/server/src/services/__tests__/keywordService.test.ts
@@ -20,7 +20,7 @@ describe('KeywordService', () => {
 
       ;(prismaMock.processedArticle.findMany as jest.Mock).mockResolvedValue(mockArticles)
 
-      const result = await keywordService.getKeywordstats(mockUserId)
+      const result = await keywordService.getUserKeywordStats(mockUserId)
 
       expect(result).toEqual([
         { keyword: 'test', count: 2 },
@@ -33,7 +33,7 @@ describe('KeywordService', () => {
 
       ;(prismaMock.processedArticle.findMany as jest.Mock).mockResolvedValue([])
 
-      const result = await keywordService.getKeywordstats(mockUserId)
+      const result = await keywordService.getUserKeywordStats(mockUserId)
 
       expect(result).toEqual([])
     })

--- a/server/src/services/__tests__/keywordService.test.ts
+++ b/server/src/services/__tests__/keywordService.test.ts
@@ -1,0 +1,41 @@
+import { prismaMock } from '../../../prisma/mock'
+import { keywordService } from '../keywordService'
+
+describe('KeywordService', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  describe('getKeywordStats', () => {
+    it('should return keyword stats', async () => {
+      const mockUserId = 1
+      const mockArticles = [
+        {
+          keywords: [{ keyword: { keyword: 'test' } }],
+        },
+        {
+          keywords: [{ keyword: { keyword: 'test' } }, { keyword: { keyword: 'example' } }],
+        },
+      ]
+
+      ;(prismaMock.processedArticle.findMany as jest.Mock).mockResolvedValue(mockArticles)
+
+      const result = await keywordService.getKeywordstats(mockUserId)
+
+      expect(result).toEqual([
+        { keyword: 'test', count: 2 },
+        { keyword: 'example', count: 1 },
+      ])
+    })
+
+    it('should return empty array when no articles found', async () => {
+      const mockUserId = 1
+
+      ;(prismaMock.processedArticle.findMany as jest.Mock).mockResolvedValue([])
+
+      const result = await keywordService.getKeywordstats(mockUserId)
+
+      expect(result).toEqual([])
+    })
+  })
+})

--- a/server/src/services/__tests__/sectionService.test.ts
+++ b/server/src/services/__tests__/sectionService.test.ts
@@ -46,55 +46,147 @@ describe('SectionService', () => {
       await expect(sectionService.getSectionById(999)).rejects.toThrow(SectionNotFoundError)
     })
   })
-})
 
-describe('createDefaultSectionPreferences', () => {
-  it('should create default section preferences for user', async () => {
-    const mockSections = [
-      { id: 1, name: 'politics' },
-      { id: 2, name: 'economy' },
-    ]
+  describe('createDefaultSectionPreferences', () => {
+    it('should create default section preferences for user', async () => {
+      const mockSections = [
+        { id: 1, name: 'politics' },
+        { id: 2, name: 'economy' },
+      ]
 
-    ;(prismaMock.articleSection.findMany as jest.Mock).mockResolvedValue(mockSections)
+      ;(prismaMock.articleSection.findMany as jest.Mock).mockResolvedValue(mockSections)
 
-    await sectionService.createDefaultSectionPreferences(1)
+      await sectionService.createDefaultSectionPreferences(1)
 
-    expect(prismaMock.userArticleSectionPreference.createMany).toHaveBeenCalledWith({
-      data: [
-        { user_id: 1, section_id: 1, preference: 1 },
-        { user_id: 1, section_id: 2, preference: 1 },
-      ],
+      expect(prismaMock.userArticleSectionPreference.createMany).toHaveBeenCalledWith({
+        data: [
+          { user_id: 1, section_id: 1, preference: 1 },
+          { user_id: 1, section_id: 2, preference: 1 },
+        ],
+      })
     })
   })
-})
 
-describe('getSectionPreferencesByUserId', () => {
-  it('should return section preferences for user', async () => {
-    const preferences = [
-      {
-        user_id: 1,
-        section_id: 1,
-        preference: 1,
-        section: { id: 1, name: 'politics' },
-      },
-      {
-        user_id: 1,
-        section_id: 2,
-        preference: 1,
-        section: { id: 2, name: 'economy' },
-      },
-    ]
+  describe('getSectionPreferencesByUserId', () => {
+    it('should return section preferences for user', async () => {
+      const preferences = [
+        {
+          user_id: 1,
+          section_id: 1,
+          preference: 1,
+          section: { id: 1, name: 'politics' },
+        },
+        {
+          user_id: 1,
+          section_id: 2,
+          preference: 1,
+          section: { id: 2, name: 'economy' },
+        },
+      ]
 
-    ;(prismaMock.userArticleSectionPreference.findMany as jest.Mock).mockResolvedValue(preferences)
+      ;(prismaMock.userArticleSectionPreference.findMany as jest.Mock).mockResolvedValue(preferences)
 
-    const result = await sectionService.getSectionPreferencesByUserId(1)
-    expect(prismaMock.userArticleSectionPreference.findMany).toHaveBeenCalledWith({
-      where: { user_id: 1 },
-      include: { section: true },
+      const result = await sectionService.getSectionPreferencesByUserId(1)
+      expect(prismaMock.userArticleSectionPreference.findMany).toHaveBeenCalledWith({
+        where: { user_id: 1 },
+        include: { section: true },
+      })
+      expect(result).toEqual([
+        { userId: 1, sectionId: 1, sectionName: 'politics', preference: 1 },
+        { userId: 1, sectionId: 2, sectionName: 'economy', preference: 1 },
+      ])
     })
-    expect(result).toEqual([
-      { userId: 1, sectionId: 1, sectionName: 'politics', preference: 1 },
-      { userId: 1, sectionId: 2, sectionName: 'economy', preference: 1 },
-    ])
+  })
+
+  describe('getUserSectionStats', () => {
+    it('should return user section stats with calculated behavior scores', async () => {
+      const mockData = [
+        {
+          id: 1,
+          name: 'politics',
+          user_article_section_preference: [{ preference: 3 }],
+          p_articles: [
+            {
+              likes: [{ id: 1, user_id: 1 }],
+              scraps: [
+                { id: 1, user_id: 1 },
+                { id: 2, user_id: 1 },
+              ],
+              ArticleViewEvent: [{ id: 1 }, { id: 2 }, { id: 3 }],
+            },
+            {
+              likes: [],
+              scraps: [],
+              ArticleViewEvent: [],
+            },
+          ],
+        },
+        {
+          id: 2,
+          name: 'economy',
+          user_article_section_preference: [], // 기본 선호도 1
+          p_articles: [
+            {
+              likes: [{ id: 3, user_id: 1 }],
+              scraps: [],
+              ArticleViewEvent: [{ id: 4 }],
+            },
+          ],
+        },
+      ]
+
+      // prismaMock.articleSection.findMany 모킹
+      ;(prismaMock.articleSection.findMany as jest.Mock).mockResolvedValue(mockData)
+
+      const result = await sectionService.getUserSectionStats(1)
+
+      expect(prismaMock.articleSection.findMany).toHaveBeenCalledWith({
+        include: {
+          user_article_section_preference: {
+            where: { user_id: 1 },
+            select: { preference: true },
+          },
+          p_articles: {
+            include: {
+              likes: { where: { user_id: 1 } },
+              scraps: { where: { user_id: 1 } },
+              ArticleViewEvent: {
+                where: { user_id: 1, event_type: 'DETAIL_VIEW' },
+              },
+            },
+          },
+        },
+      })
+
+      expect(result).toEqual([
+        {
+          sectionId: 1,
+          sectionName: 'politics',
+          preference: 3,
+          // scrapCount = 2 → 2*5 = 10
+          // likeCount = 1 → 1*3 = 3
+          // detailViewCount = 3 → 3*2 = 6
+          // 합계 = 10 + 3 + 6 = 19
+          behaviorScore: 19,
+        },
+        {
+          sectionId: 2,
+          sectionName: 'economy',
+          preference: 1, // 기본값
+          // scrapCount = 0
+          // likeCount = 1 → 3
+          // detailViewCount = 1 → 2
+          // 합계 = 0 + 3 + 2 = 5
+          behaviorScore: 5,
+        },
+      ])
+    })
+
+    it('should handle empty sections and return empty array', async () => {
+      ;(prismaMock.articleSection.findMany as jest.Mock).mockResolvedValue([])
+
+      const result = await sectionService.getUserSectionStats(1)
+      expect(result).toEqual([])
+    })
   })
 })

--- a/server/src/services/keywordService.ts
+++ b/server/src/services/keywordService.ts
@@ -1,0 +1,40 @@
+import { prisma } from '../../prisma/prisma'
+import { KeywordCount } from '../types/keyword'
+
+export const keywordService = {
+  /**
+   * 사용자가 상호작용한 기사에서 키워드 통계를 가져옵니다.
+   * @param {number} userId - 사용자의 ID
+   * @returns {Promise<KeywordCount[]>} - 키워드 통계 배열
+   */
+  getKeywordstats: async (userId: number): Promise<KeywordCount[]> => {
+    const interactedArticles = await prisma.processedArticle.findMany({
+      where: {
+        OR: [
+          { likes: { some: { user_id: userId } } },
+          { scraps: { some: { user_id: userId } } },
+          { ArticleViewEvent: { some: { user_id: userId } } },
+        ],
+      },
+      include: {
+        keywords: { select: { keyword: true } },
+      },
+    })
+
+    const keywordCountMap = new Map<string, number>()
+
+    interactedArticles.forEach((article) => {
+      article.keywords.forEach((km) => {
+        const key = km.keyword.keyword
+        keywordCountMap.set(key, (keywordCountMap.get(key) || 0) + 1)
+      })
+    })
+
+    const keywordStats: KeywordCount[] = Array.from(keywordCountMap.entries()).map(([keyword, count]) => ({
+      keyword,
+      count,
+    }))
+
+    return keywordStats.sort((a, b) => b.count - a.count)
+  },
+}

--- a/server/src/services/keywordService.ts
+++ b/server/src/services/keywordService.ts
@@ -7,7 +7,7 @@ export const keywordService = {
    * @param {number} userId - 사용자의 ID
    * @returns {Promise<KeywordCount[]>} - 키워드 통계 배열
    */
-  getKeywordstats: async (userId: number): Promise<KeywordCount[]> => {
+  getUserKeywordStats: async (userId: number): Promise<KeywordCount[]> => {
     const interactedArticles = await prisma.processedArticle.findMany({
       where: {
         OR: [

--- a/server/src/swagger/openapi.yaml
+++ b/server/src/swagger/openapi.yaml
@@ -922,6 +922,64 @@ paths:
                     success: false
                     message: Internal server error
 
+  /users/mypage-stats:
+    get:
+      summary: 사용자 마이페이지 통계 조회
+      description: 사용자의 마이페이지 통계를 조회합니다. 헤더에 JWT 토큰을 포함해야 합니다.
+      responses:
+        '200':
+          description: 마이페이지 통계 조회 성공
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    example: true
+                  data:
+                    type: object
+                    properties:
+                      user:
+                        $ref: '#/components/schemas/User'
+                      sectionStats:
+                        type: array
+                        items:
+                          $ref: '#/components/schemas/SectionStat'
+                      keywordStats:
+                        type: array
+                        items:
+                          $ref: '#/components/schemas/KeywordStat'
+                  message:
+                    type: string
+                    example: User stats retrieved successfully
+
+        '401':
+          description: 인증 실패 (토큰이 없거나 유효하지 않음)
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                unauthorized:
+                  summary: 인증 실패
+                  value:
+                    success: false
+                    message: User ID is required
+
+        '500':
+          description: 서버 오류
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                serverError:
+                  summary: 서버 오류
+                  value:
+                    success: false
+                    message: Internal server error
+
   /sections:
     get:
       summary: 섹션 목록 조회
@@ -1210,6 +1268,32 @@ components:
           type: string
           format: date-time
           example: '2023-09-21T12:00:00.000Z'
+
+    SectionStat:
+      type: object
+      properties:
+        sectionId:
+          type: integer
+          example: 1
+        sectionName:
+          type: string
+          example: 'politics'
+        preference:
+          type: integer
+          example: 1
+        behaviorScore:
+          type: integer
+          example: 100
+
+    KeywordStat:
+      type: object
+      properties:
+        keyword:
+          type: string
+          example: 'election'
+        count:
+          type: integer
+          example: 50
 
     ArticleCursorPaginationResponse:
       type: object

--- a/server/src/types/keyword.ts
+++ b/server/src/types/keyword.ts
@@ -1,0 +1,7 @@
+/**
+ * 키워드 통계 정보
+ */
+export type KeywordCount = {
+  keyword: string
+  count: number
+}

--- a/server/src/types/section.ts
+++ b/server/src/types/section.ts
@@ -7,3 +7,14 @@ export type UserSectionPreference = {
   sectionName: string
   preference: number
 }
+
+/**
+ * 섹션의 행동 점수를 나타내는 타입입니다.
+ * 사용자의 섹션 선호도와 행동 점수를 포함합니다.
+ */
+export type UserSectionStat = {
+  sectionId: number
+  sectionName: string
+  preference: number
+  behaviorScore: number
+}


### PR DESCRIPTION
# Changelog
- 마이페이지 API를 구현하였습니다. 다음의 정보를 포함합니다.
  - user: `userService.getUserById(userId)` 정보
  - sectionStats: `sectionService.getUserSectionStats(userId)` 정보
  - keywordStats: `keywordService.getUserKeywordStats(userId)` 정보

# Testing
- 유닛테스트
<img width="684" height="635" alt="image" src="https://github.com/user-attachments/assets/fc61b7db-be98-482d-9340-d0232df66f4c" />

- `GET /api/users/mypage-stats` 결과
```
{
    "success": true,
    "data": {
        "user": {
            "id": 2,
            "nickname": "귀여운 토끼 #1",
            "phone": "01012345678",
            "is_authenticated": true,
            "created_at": "2025-07-26T12:16:26.503Z",
            "updated_at": "2025-07-26T12:16:26.503Z"
        },
        "sectionStats": [
            {
                "sectionId": 1,
                "sectionName": "politics",
                "preference": 2,
                "behaviorScore": 6
            },
            {
                "sectionId": 2,
                "sectionName": "economy",
                "preference": 3,
                "behaviorScore": 0
            },
            {
                "sectionId": 3,
                "sectionName": "society",
                "preference": 3,
                "behaviorScore": 5
            },
            {
                "sectionId": 4,
                "sectionName": "culture",
                "preference": 1,
                "behaviorScore": 3
            },
            {
                "sectionId": 5,
                "sectionName": "tech",
                "preference": 1,
                "behaviorScore": 0
            },
            {
                "sectionId": 6,
                "sectionName": "world",
                "preference": 1,
                "behaviorScore": 0
            }
        ],
        "keywordStats": [
            {
                "keyword": "싱어롱",
                "count": 1
            },
            {
                "keyword": "공동체",
                "count": 1
            },
            {
                "keyword": "이한나",
                "count": 1
            }
        ]
    },
    "message": "User stats retrieved successfully"
}
```


# Ops Impact
N/A

# Version Compatibility
N/A