### PR TITLE
[Server] 잘못된 mock Article 수정

### DIFF
--- a/server/src/services/__tests__/articleService.test.ts
+++ b/server/src/services/__tests__/articleService.test.ts
@@ -516,7 +516,8 @@ describe('ArticleService', () => {
       full_summary: 'Test full summary',
       language: 'ko',
       region: 'KR',
-      section: 'tech',
+      section_id: 1,
+      thumbnail_url: 'http://example.com/thumbnail.jpg',
       created_at: new Date('2024-01-01T00:00:00Z'),
     }
 


### PR DESCRIPTION
# Changelog
- `articleService.test.ts`에서 `section` 대신 `section_id`를 가지고, 더미 `thumbnail_url`을 가지도록 수정하였습니다.

# Testing
<img width="687" height="799" alt="image" src="https://github.com/user-attachments/assets/048deea0-6500-4e88-8b61-dc442b8a36a5" />


# Ops Impact
N/A

# Version Compatibility
N/A