### PR TITLE
[Server] Article API 쿼리 파라미터 추가 및 리팩토링

### DIFF
--- a/server/src/swagger/openapi.yaml
+++ b/server/src/swagger/openapi.yaml
@@ -302,6 +302,16 @@ paths:
           schema:
             type: string
           description: 커서 값 (이후 페이지 조회 시 사용)
+        - in: query
+          name: scrapped
+          schema:
+            type: boolean
+          description: 스크랩된 기사만 조회할지 여부 (기본값 false)
+        - in: query
+          name: liked
+          schema:
+            type: boolean
+          description: 좋아요한 기사만 조회할지 여부 (기본값 false)
       responses:
         '200':
           description: 기사 목록 조회 성공


### PR DESCRIPTION
# Changelog
- `GET /api/articles` 에 아래의 Query Parameter를 추가하였습니다.
  - `scraped`: 해당 사용자가 스크랩한 기사만 반환
  - `liked`: 해당 사용자가 좋아요 한 기사만 반환
  - 만약 위 두 개의 parameter가 주어지지 않은 경우, 추천 기사가 반환됩니다.
- `getArticlesByCursor`라는 커서 기반 뉴스 반환 함수를 만들고, 아래의 함수에서 사용하는 방법으로 리팩토링하였습니다.
  - `getRecommendedArticlesByCursor`:  해당 사용자의 추천 점수 기반으로 뉴스 ID를 가져오고, `getArticlesByCursor`에 전달
  - `getScrapedArticlesByCursor`: 해당 사용자가 스크랩한 뉴스들의 ID를 가져오고, `getArticlesByCursor`에 전달
  - `getLikedArticlesByCursor`: 해당 사용자가 좋아요한 뉴스들의 ID를 가져오고, `getArticlesByCursor`에 전달

# Testing
- 유닛테스트
<img width="714" height="1113" alt="image" src="https://github.com/user-attachments/assets/e07fb211-8ed4-444e-9391-7c2889b286c7" />

- Postman 테스트

# Ops Impact
N/A

# Version Compatibility
N/A