### PR TITLE
[Server] 5분 하이라이트 뉴스 구현

### DIFF
--- a/server/main.ts
+++ b/server/main.ts
@@ -12,6 +12,7 @@ import articleRouter from './src/routes/article'
 import authRouter from './src/routes/auth'
 import userRouter from './src/routes/user'
 import sectionRouter from './src/routes/section'
+import { registerCronJobs } from './src/utils/cron'
 
 const swaggerYamlPath = path.join(__dirname, './build/swagger.yaml')
 const swaggerDocument = YAML.load(swaggerYamlPath)
@@ -20,12 +21,14 @@ redisClient.connect()
 
 const app = Express()
 app.use(Express.json())
-
 app.use('/api-docs', swaggerUi.serve, swaggerUi.setup(swaggerDocument))
 app.use('/api/articles', articleRouter)
 app.use('/api/auth', authRouter)
 app.use('/api/users', userRouter)
 app.use('/api/sections', sectionRouter)
+
+// Cron Jobs 등록
+registerCronJobs()
 
 const PORT = process.env.PORT || 3000
 

--- a/server/package.json
+++ b/server/package.json
@@ -19,6 +19,7 @@
     "express": "^4.21.0",
     "google-auth-library": "^10.2.1",
     "jsonwebtoken": "^9.0.2",
+    "node-cron": "^4.2.1",
     "string-hash": "^1.1.3",
     "swagger-cli": "^4.0.4",
     "swagger-ui-express": "^5.0.1",

--- a/server/pnpm-lock.yaml
+++ b/server/pnpm-lock.yaml
@@ -32,6 +32,9 @@ importers:
       jsonwebtoken:
         specifier: ^9.0.2
         version: 9.0.2
+      node-cron:
+        specifier: ^4.2.1
+        version: 4.2.1
       string-hash:
         specifier: ^1.1.3
         version: 1.1.3
@@ -1763,6 +1766,10 @@ packages:
   node-addon-api@8.4.0:
     resolution: {integrity: sha512-D9DI/gXHvVmjHS08SVch0Em8G5S1P+QWtU31appcKT/8wFSPRcdHadIFSAntdMMVM5zz+/DL+bL/gz3UDppqtg==}
     engines: {node: ^18 || ^20 || >= 21}
+
+  node-cron@4.2.1:
+    resolution: {integrity: sha512-lgimEHPE/QDgFlywTd8yTR61ptugX3Qer29efeyWw2rv259HtGBNn1vZVmp8lB9uo9wC0t/AT4iGqXxia+CJFg==}
+    engines: {node: '>=6.0.0'}
 
   node-domexception@1.0.0:
     resolution: {integrity: sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==}
@@ -4367,6 +4374,8 @@ snapshots:
   negotiator@0.6.3: {}
 
   node-addon-api@8.4.0: {}
+
+  node-cron@4.2.1: {}
 
   node-domexception@1.0.0: {}
 

--- a/server/src/controllers/__tests__/articleController.test.ts
+++ b/server/src/controllers/__tests__/articleController.test.ts
@@ -142,6 +142,28 @@ describe('articleController', () => {
       })
     })
 
+    it('should return highlight articles successfully', async () => {
+      req.userId = 1
+      req.query = { limit: '10', highlight: 'true' }
+
+      const mockHighlightArticlesByCursor = {
+        data: [{ id: 1, title: 'Article 1' }],
+        hasNext: false,
+        nextCursor: null,
+      }
+
+      ;(articleService.getHighlightArticlesByCursor as jest.Mock).mockResolvedValue(mockHighlightArticlesByCursor)
+
+      await getArticles(req, res)
+
+      expect(articleService.getHighlightArticlesByCursor).toHaveBeenCalledWith(1, 10, undefined)
+      expect(mockSuccessWithCursor).toHaveBeenCalledWith(res, mockHighlightArticlesByCursor.data, {
+        hasNext: mockHighlightArticlesByCursor.hasNext,
+        nextCursor: mockHighlightArticlesByCursor.nextCursor,
+        message: 'Articles retreived successfully',
+      })
+    })
+
     it('should return not found if no articles are found', async () => {
       req.userId = 1
       req.query = { limit: '10' }

--- a/server/src/controllers/articleController.ts
+++ b/server/src/controllers/articleController.ts
@@ -23,6 +23,7 @@ export const getArticles = async (req: AuthenticatedRequest, res: Response) => {
   const cursor = req.query.cursor as string | undefined
   const scrapped: boolean = req.query.scraped === 'true'
   const liked: boolean = req.query.liked === 'true'
+  const highlight: boolean = req.query.highlight === 'true'
 
   if (!limit || limit < 1 || limit > 100) {
     return errors.badRequest(res, 'Invalid limit. It must be a number between 1 and 100.')
@@ -34,6 +35,8 @@ export const getArticles = async (req: AuthenticatedRequest, res: Response) => {
       result = await articleService.getScrapedArticlesByCursor(userId, limit, cursor)
     } else if (liked) {
       result = await articleService.getLikedArticlesByCursor(userId, limit, cursor)
+    } else if (highlight) {
+      result = await articleService.getHighlightArticlesByCursor(userId, limit, cursor)
     } else {
       result = await articleService.getRecommendedArticlesByCursor(userId, limit, cursor)
     }

--- a/server/src/services/__tests__/articleService.test.ts
+++ b/server/src/services/__tests__/articleService.test.ts
@@ -111,6 +111,9 @@ const mockDetailedArticle: DetailedProcessedArticle = {
 describe('ArticleService', () => {
   beforeEach(() => {
     jest.clearAllMocks()
+  })
+
+  afterEach(() => {
     jest.restoreAllMocks()
   })
 
@@ -562,6 +565,30 @@ describe('ArticleService', () => {
     })
   })
 
+  describe('fetchHighlightedArticleIds', () => {
+    const mockHighlightArticleCache = {
+      articleIds: [1, 2, 3],
+      lastUpdated: new Date(),
+    }
+
+    it('should return highlighed article IDs', async () => {
+      ;(redisClient.get as jest.Mock).mockResolvedValue(JSON.stringify(mockHighlightArticleCache))
+
+      const result = await articleService.fetchHighlightedArticleIds()
+
+      expect(result).toEqual([1, 2, 3])
+    })
+
+    it('should update cache when no cache', async () => {
+      ;(redisClient.get as jest.Mock).mockResolvedValue(undefined)
+      jest.spyOn(articleService, 'updateHighlightArticles').mockResolvedValue(mockHighlightArticleCache)
+
+      const result = await articleService.fetchHighlightedArticleIds()
+
+      expect(result).toEqual([1, 2, 3])
+    })
+  })
+
   describe('getRecommendedArticleByCursor', () => {
     it('should return getArticlesByCursor with correct parameters', async () => {
       const userId = 1
@@ -621,6 +648,27 @@ describe('ArticleService', () => {
       const result = await articleService.getLikedArticlesByCursor(userId, limit, cursor)
 
       expect(articleService.fetchLikedArticleIds).toHaveBeenCalledWith(userId)
+      expect(articleService.getArticlesByCursor).toHaveBeenCalledWith(mockArticleIds, userId, limit, cursor)
+    })
+  })
+
+  describe('getHighlightArticlesByCursor', () => {
+    it('should return getArticlesByCursor with correct parameters', async () => {
+      const userId = 1
+      const limit = 10
+      const cursor = 'test-cursor'
+      const mockArticleIds = [1, 2, 3]
+
+      jest.spyOn(articleService, 'fetchHighlightedArticleIds').mockResolvedValue(mockArticleIds)
+      jest.spyOn(articleService, 'getArticlesByCursor').mockResolvedValue({
+        data: [],
+        hasNext: false,
+        nextCursor: 'next-cursor',
+      })
+
+      const result = await articleService.getHighlightArticlesByCursor(userId, limit, cursor)
+
+      expect(articleService.fetchHighlightedArticleIds).toHaveBeenCalled()
       expect(articleService.getArticlesByCursor).toHaveBeenCalledWith(mockArticleIds, userId, limit, cursor)
     })
   })
@@ -824,6 +872,107 @@ describe('ArticleService', () => {
       prismaMock.scrap.deleteMany.mockRejectedValue(error)
 
       await expect(articleService.unscrapArticle(userId, articleId)).rejects.toThrow('Database connection failed')
+    })
+  })
+
+  describe('updateHighlightArticles', () => {
+    const fixedDate = new Date('2025-08-14T00:00:00.000Z')
+
+    beforeAll(() => {
+      jest.useFakeTimers()
+      jest.setSystemTime(fixedDate)
+    })
+
+    afterAll(() => {
+      jest.useRealTimers()
+    })
+
+    const articles = [
+      {
+        id: 1,
+        title: 'Highlight Article 1',
+        likes: [{ user_id: 1 }],
+        scraps: [{ user_id: 1 }],
+        ArticleViewEvent: [{ user_id: 1 }],
+        articles: [{ provider: { id: 1 } }],
+      },
+      {
+        id: 2,
+        title: 'Highlight Article 2',
+        likes: [{ user_id: 1 }, { user_id: 2 }],
+        scraps: [{ user_id: 1 }, { user_id: 2 }],
+        ArticleViewEvent: [{ user_id: 1 }, { user_id: 2 }],
+        articles: [{ provider: { id: 1 } }, { provider: { id: 2 } }],
+      },
+      {
+        id: 3,
+        title: 'Highlight Article 3',
+        likes: [],
+        scraps: [],
+        ArticleViewEvent: [],
+        articles: [{ provider: { id: 1 } }],
+      },
+    ]
+
+    it('Successfully updates highlight articles for a given date', async () => {
+      const fromDate = new Date('2025-08-14T00:00:00Z')
+      const numArticles = 2
+      ;(prismaMock.processedArticle.findMany as jest.Mock).mockResolvedValue(articles)
+      ;(redisClient.setEx as jest.Mock).mockResolvedValue('OK')
+
+      const result = await articleService.updateHighlightArticles(fromDate, numArticles)
+
+      expect(prismaMock.processedArticle.findMany).toHaveBeenCalledWith({
+        include: {
+          likes: true,
+          scraps: true,
+          ArticleViewEvent: true,
+          articles: { select: { provider: true } },
+        },
+        where: { created_at: { gte: fromDate.toISOString() } },
+      })
+
+      expect(result.articleIds).toEqual([2, 1])
+      expect(result.lastUpdated).toEqual(fixedDate)
+
+      expect(redisClient.setEx).toHaveBeenCalledWith(
+        'highlight-articles',
+        3600 * 24, // 24시간
+        JSON.stringify({
+          articleIds: [2, 1], // 기사 2(20점), 기사 1(12점) 순
+          lastUpdated: fixedDate.toISOString(),
+        }),
+      )
+    })
+
+    it('Should use default number of articles if not provided', async () => {
+      const fromDate = new Date('2025-08-13T00:00:00Z')
+      ;(prismaMock.processedArticle.findMany as jest.Mock).mockResolvedValue(articles)
+      ;(redisClient.setEx as jest.Mock).mockResolvedValue('OK')
+
+      const result = await articleService.updateHighlightArticles(fromDate)
+
+      expect(prismaMock.processedArticle.findMany).toHaveBeenCalledWith({
+        include: {
+          likes: true,
+          scraps: true,
+          ArticleViewEvent: true,
+          articles: { select: { provider: true } },
+        },
+        where: { created_at: { gte: fromDate.toISOString() } },
+      })
+
+      expect(result.articleIds).toEqual([2, 1, 3])
+      expect(result.lastUpdated).toEqual(fixedDate)
+
+      expect(redisClient.setEx).toHaveBeenCalledWith(
+        'highlight-articles',
+        3600 * 24,
+        JSON.stringify({
+          articleIds: [2, 1, 3], // 점수순: 기사2(20점), 기사1(12점), 기사3(2점)
+          lastUpdated: fixedDate.toISOString(),
+        }),
+      )
     })
   })
 })

--- a/server/src/services/articleService.ts
+++ b/server/src/services/articleService.ts
@@ -1,12 +1,19 @@
 import { ArticleViewEventType, ProcessedArticle } from '@prisma/client'
 import { prisma } from '../../prisma/prisma'
-import { ArticleSimilarityRow, DetailedProcessedArticle, UserArticleCache } from '../types/article'
+import {
+  ArticleSimilarityRow,
+  DetailedProcessedArticle,
+  HighlightArticleCache,
+  UserArticleCache,
+} from '../types/article'
 import { redisClient } from '../config/redis'
 import { createCursor, decodeCursor } from '../utils/cursor'
 import dayjs from 'dayjs'
 import { bigqueryClient } from '../config/bigquery'
 
 const RECOMMENDATION_CACHE_EXPIRATION = 3600 * 6 // 6시간
+const HIGHLIGHT_CACHE_KEY = 'highlight-articles' // Redis에서 하이라이트 기사를 저장할 키
+const HIGHLIGHT_CACHE_EXPIRATION = 3600 * 24 // 24 시간
 
 /**
  * 커서 페이지네이션을 사용하여 기사를 조회하는 결과 형식입니다.
@@ -228,6 +235,25 @@ export const articleService = {
   },
 
   /**
+   * 하이라이트 기사 ID를 조회합니다.
+   * Redis에 캐싱 데이터가 있는지 먼저 확인하고, 없는 경우 캐시를 업데이트합니다.
+   * @return Promise<number[]> - 하이라이트 기사 ID 배열
+   */
+  fetchHighlightedArticleIds: async (): Promise<number[]> => {
+    const cached = await redisClient.get(HIGHLIGHT_CACHE_KEY)
+
+    if (cached) {
+      const data = JSON.parse(cached) as HighlightArticleCache
+      return data.articleIds
+    }
+
+    // 캐시가 없으면 하이라이트 기사를 업데이트합니다.
+    const yesterday = dayjs().subtract(1, 'day').startOf('day').toDate()
+    const highlightArticles: HighlightArticleCache = await articleService.updateHighlightArticles(yesterday)
+    return highlightArticles.articleIds
+  },
+
+  /**
    * 추천된 기사들을 커서 페이지네이션으로 조회합니다.
    * 이 함수는 사용자의 추천 기사 ID를 가져와 커서와 한계에 따라 결과를 반환합니다.
    * @param userId - 추천 기사를 조회할 사용자의 ID
@@ -284,6 +310,23 @@ export const articleService = {
     cursor?: string,
   ): Promise<ArticleCursorPaginationResult> => {
     const articleIds = await articleService.fetchLikedArticleIds(userId)
+    return articleService.getArticlesByCursor(articleIds, userId, limit, cursor)
+  },
+
+  /**
+   * 하이라이트 기사들을 커서 페이지네이션으로 조회합니다.
+   * 이 함수는 하이라이트 기사 ID를 가져와 커서와 한계에 따라 결과를 반환합니다.
+   * @param userId - 요청 사용자 ID
+   * @param limit - 한 번에 조회할 기사 수
+   * @param cursor - 다음 페이지를 조회하기 위한 커서 (Optional)
+   * @return Promise<ArticleCursorPaginationResult> - 커서 페이지네이션 결과
+   */
+  getHighlightArticlesByCursor: async (
+    userId: number,
+    limit: number,
+    cursor?: string,
+  ): Promise<ArticleCursorPaginationResult> => {
+    const articleIds = await articleService.fetchHighlightedArticleIds()
     return articleService.getArticlesByCursor(articleIds, userId, limit, cursor)
   },
 
@@ -554,5 +597,53 @@ export const articleService = {
         p_article_id: articleId,
       },
     })
+  },
+
+  /**
+   * 하이라이트 기사를 업데이트합니다.
+   * 이 함수는 최근 생성된 기사들을 분석하여 하이라이트 기사를 결정하고 Redis에 캐싱합니다.
+   * @param fromDate - 하이라이트 뉴스가 될 후보 뉴스의 시작 날짜
+   * @param numArticles - 업데이트할 하이라이트 기사 수 (기본값: 15)
+   * @return Promise<void> - 하이라이트 기사 업데이트가 완료되면 반환되는 프로미스
+   * @example
+   * // 최근 7일 이내의 기사를 기준으로 하이라이트 기사 업데이트
+   * updateHighlightArticles(new Date(Date.now() - 7 * 24 * 60 * 60 * 1000))
+   */
+  updateHighlightArticles: async (fromDate: Date, numArticles: number = 15): Promise<HighlightArticleCache> => {
+    const articles = await prisma.processedArticle.findMany({
+      include: {
+        likes: true,
+        scraps: true,
+        ArticleViewEvent: true,
+        articles: { select: { provider: true } },
+      },
+      where: { created_at: { gte: fromDate.toISOString() } },
+    })
+
+    // 기사의 점수를 계산합니다.
+    // 스크랩 수 * 5 + 좋아요 수 * 3 + 상세 조회 수 * 2 + 제공자 수 * 2
+    const articleScores = articles.map((article) => {
+      const scrapScore = article.scraps.length * 5
+      const likeScore = article.likes.length * 3
+      const detailViewScore = article.ArticleViewEvent.length * 2
+
+      const providerCount = new Set(article.articles.map((a) => a.provider.id)).size
+      const providerCountScore = providerCount * 2
+
+      return {
+        ...article,
+        score: scrapScore + likeScore + detailViewScore + providerCountScore,
+      }
+    })
+
+    const topArticles = articleScores.sort((a, b) => b.score - a.score).slice(0, numArticles)
+    const highlightArticleCache: HighlightArticleCache = {
+      articleIds: topArticles.map((a) => a.id),
+      lastUpdated: dayjs().toDate(),
+    }
+
+    redisClient.setEx(HIGHLIGHT_CACHE_KEY, HIGHLIGHT_CACHE_EXPIRATION, JSON.stringify(highlightArticleCache))
+
+    return highlightArticleCache
   },
 }

--- a/server/src/services/articleService.ts
+++ b/server/src/services/articleService.ts
@@ -83,6 +83,10 @@ export const articleService = {
    *  calculateSimilarityAndSort(1, [101, 102, 103])
    */
   calculateSimilarityAndSort: async (userId: number, candidateArticleIds: number[]): Promise<number[]> => {
+    if (candidateArticleIds.length === 0) {
+      return []
+    }
+
     const query = `
       WITH user_embedding AS (
         SELECT embedding_vector
@@ -152,7 +156,10 @@ export const articleService = {
       lastUpdated: new Date(),
     }
 
-    await articleService.setCachedRecommendations(userId, newCache)
+    if (newCache.articleIds.length > 0) {
+      await articleService.setCachedRecommendations(userId, newCache)
+    }
+
     return newCache
   },
 
@@ -642,7 +649,9 @@ export const articleService = {
       lastUpdated: dayjs().toDate(),
     }
 
-    redisClient.setEx(HIGHLIGHT_CACHE_KEY, HIGHLIGHT_CACHE_EXPIRATION, JSON.stringify(highlightArticleCache))
+    if (highlightArticleCache.articleIds.length > 0) {
+      redisClient.setEx(HIGHLIGHT_CACHE_KEY, HIGHLIGHT_CACHE_EXPIRATION, JSON.stringify(highlightArticleCache))
+    }
 
     return highlightArticleCache
   },

--- a/server/src/swagger/openapi.yaml
+++ b/server/src/swagger/openapi.yaml
@@ -312,6 +312,11 @@ paths:
           schema:
             type: boolean
           description: 좋아요한 기사만 조회할지 여부 (기본값 false)
+        - in: query
+          name: highlight
+          schema:
+            type: boolean
+          description: 하이라이트(5분 뉴스) 기사만 조회할지 여부 (기본값 false)
       responses:
         '200':
           description: 기사 목록 조회 성공

--- a/server/src/types/article.ts
+++ b/server/src/types/article.ts
@@ -9,6 +9,14 @@ export interface UserArticleCache {
 }
 
 /**
+ * 하이라이트 기사 캐싱을 위한 인터페이스입니다.
+ */
+export interface HighlightArticleCache {
+  articleIds: number[]
+  lastUpdated: Date
+}
+
+/**
  * BigQuery에서 반환되는 기사 유사도 결과 인터페이스입니다.
  */
 export interface ArticleSimilarityRow {

--- a/server/src/utils/cron.ts
+++ b/server/src/utils/cron.ts
@@ -1,0 +1,11 @@
+import dayjs from 'dayjs'
+import cron from 'node-cron'
+import { articleService } from '../services/articleService'
+
+export const registerCronJobs = () => {
+  // 하이라이트 뉴스 업데이트 작업을 매일 자정에 실행
+  cron.schedule('0 0 * * *', async () => {
+    const yesterday = dayjs().subtract(1, 'day').startOf('day').toDate()
+    articleService.updateHighlightArticles(yesterday)
+  })
+}


### PR DESCRIPTION
# Changelog
- 하이라이트 뉴스를 생성하는 `articleService.updateHighlightArticles` 함수를 생성하였습니다.
  - `스크랩 5점, 좋아요 3점, 자세히 보기 2점, 뉴스사 개수 * 2점` 으로 뉴스별 점수를 계산하여 가장 사용자들의 관심이 높았던 뉴스 15개를 추출합니다.
  - 추출된 뉴스는 Redis에 24시간동안 캐싱됩니다.
- `node-cron`을 사용하여 정각마다 하이라이트 뉴스를 업데이트하도록 설정하였습니다.

# Testing
- 유닛테스트
<img width="853" height="946" alt="image" src="https://github.com/user-attachments/assets/97ee026a-db13-49ee-8acd-d3ea1d7502b3" />

# Ops Impact
N/A

# Version Compatibility
N/A