### PR TITLE
[Server][Terraform] 백엔드 서버 Dockefile 및 Registry 생성

### DIFF
--- a/server/.gitignore
+++ b/server/.gitignore
@@ -2,3 +2,4 @@ node_modules/
 .env
 coverage/
 build/
+dist/

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,0 +1,23 @@
+FROM node:20-alpine3.16 AS base
+
+ARG NODE_ENV=production
+ENV NODE_ENV=$NODE_ENV
+ENV CI=1
+
+RUN corepack enable
+
+COPY . /app
+WORKDIR /app
+
+FROM base AS build
+RUN --mount=type=cache,id=pnpm,target=/pnpm/store pnpm install --frozen-lockfile
+RUN apk add --no-cache openssl
+RUN pnpm run db:generate
+RUN pnpm run build
+
+FROM base AS prod
+COPY --from=build /app/node_modules /app/node_modules
+COPY --from=build /app/dist /app/dist
+
+EXPOSE 8000
+CMD ["pnpm", "start"]

--- a/server/jest.config.ts
+++ b/server/jest.config.ts
@@ -4,4 +4,5 @@ module.exports = {
   testEnvironment: 'node',
   setupFilesAfterEnv: ['./prisma/mock.ts'],
   setupFiles: ['./jest.env.ts'],
+  roots: ['<rootDir>/src'],
 }

--- a/server/main.ts
+++ b/server/main.ts
@@ -14,14 +14,17 @@ import userRouter from './src/routes/user'
 import sectionRouter from './src/routes/section'
 import { registerCronJobs } from './src/utils/cron'
 
-const swaggerYamlPath = path.join(__dirname, './build/swagger.yaml')
-const swaggerDocument = YAML.load(swaggerYamlPath)
-
 redisClient.connect()
 
 const app = Express()
 app.use(Express.json())
-app.use('/api-docs', swaggerUi.serve, swaggerUi.setup(swaggerDocument))
+
+if (process.env.NODE_ENV !== 'production') {
+  const swaggerYamlPath = path.join(__dirname, './build/swagger.yaml')
+  const swaggerDocument = YAML.load(swaggerYamlPath)
+  app.use('/api-docs', swaggerUi.serve, swaggerUi.setup(swaggerDocument))
+}
+
 app.use('/api/articles', articleRouter)
 app.use('/api/auth', authRouter)
 app.use('/api/users', userRouter)

--- a/server/package.json
+++ b/server/package.json
@@ -6,9 +6,12 @@
   "scripts": {
     "predev": "pnpm run api-docs",
     "dev": "nodemon main.ts",
+    "start": "node dist/main.js",
     "test": "jest",
-    "init_db": "npx prisma migrate deploy && npx prisma generate && npx ts-node ./prisma/seed.ts",
-    "api-docs": "swagger-cli bundle ./src/swagger/openapi.yaml --outfile build/swagger.yaml --type yaml"
+    "db:generate": "npx prisma generate",
+    "db:migrate": "npx prisma migrate deploy",
+    "api-docs": "swagger-cli bundle ./src/swagger/openapi.yaml --outfile build/swagger.yaml --type yaml",
+    "build": "tsc"
   },
   "dependencies": {
     "@google-cloud/bigquery": "^8.1.1",

--- a/server/tsconfig.json
+++ b/server/tsconfig.json
@@ -1,6 +1,12 @@
 {
   "extends": "@tsconfig/node20/tsconfig.json",
   "compilerOptions": {
-    "isolatedModules": true
-  }
+    "isolatedModules": true,
+    "outDir": "./dist"
+  },
+  "exclude": [
+    "src/**/*.spec.ts",
+    "src/**/*.test.ts",
+    "node_modules"
+  ]
 }

--- a/terraform/registry.tf
+++ b/terraform/registry.tf
@@ -1,0 +1,7 @@
+resource "google_artifact_registry_repository" "server" {
+  project       = var.project
+  location      = var.region
+  repository_id = "server"
+  format        = "DOCKER"
+  description   = "somes-up Server Repository"
+}


### PR DESCRIPTION
# Changelog
- 백엔드 서버 이미지를 만드는 Dockerfile을 구성하였습니다.
  - Prisma가 아직 완벽하게 Openssl 3.x 를 지원하지 않는 것 같아, Openssl 1.1 을 지원하는 `node:20-alpine3.16` 을 베이스 이미지로 사용하였습니다.
  - ARG로 `NODE_ENV`를 받아서 환경변수로 지정하고, production인 경우 Swagger를 생성하지 않도록 구성하였습니다.
- 빌드 시 `dist/`에 저장되는 파일이 `src/` 의 코드와 겹쳐 테스트 시 중복된 경로 에러가 발생하지 않도록 `jest.config.ts`에 `rootDir`을 지정해주었습니다.
- 서버 이미지를 저장하는 GCR을 생성하였습니다.

# Testing
- 이미지 생성 결과
<img width="1273" height="672" alt="image" src="https://github.com/user-attachments/assets/b42789a1-c851-4342-84f6-41672a8928b8" />

- 로컬에 컨테이너 실행하여 아무 요청 전송 후 응답 확인
<img width="694" height="479" alt="image" src="https://github.com/user-attachments/assets/90a4d53c-a939-4aa3-ab34-39ca6acf54f7" />

- GCR에 이미지 푸시 결과
<img width="572" height="99" alt="image" src="https://github.com/user-attachments/assets/d5638f6b-a14d-4634-bb6c-61626494393e" />


# Ops Impact
N/A

# Version Compatibility
N/A