### PR TITLE
[Server] 마이페이지 행동 점수 정규화

### DIFF
--- a/server/src/services/__tests__/sectionService.test.ts
+++ b/server/src/services/__tests__/sectionService.test.ts
@@ -167,7 +167,8 @@ describe('SectionService', () => {
           // likeCount = 1 → 1*3 = 3
           // detailViewCount = 3 → 3*2 = 6
           // 합계 = 10 + 3 + 6 = 19
-          behaviorScore: 19,
+          // normalized = 1 + ((19 - 5) / (19 - 5)) * (3- 1) = 1 + 1 * 2 =3
+          behaviorScore: 3,
         },
         {
           sectionId: 2,
@@ -177,7 +178,8 @@ describe('SectionService', () => {
           // likeCount = 1 → 3
           // detailViewCount = 1 → 2
           // 합계 = 0 + 3 + 2 = 5
-          behaviorScore: 5,
+          // normalized = 1 + ((5- 5) / (19 - 5)) * (3 - 1) = 1 + 0 * 2 = 1
+          behaviorScore: 1,
         },
       ])
     })
@@ -187,6 +189,36 @@ describe('SectionService', () => {
 
       const result = await sectionService.getUserSectionStats(1)
       expect(result).toEqual([])
+    })
+
+    it('should not be normalized if there is only one section', async () => {
+      const mockData = [
+        {
+          id: 1,
+          name: 'politics',
+          user_article_section_preference: [{ preference: 3 }],
+          p_articles: [
+            {
+              likes: [{ id: 1, user_id: 1 }],
+              scraps: [],
+              ArticleViewEvent: [],
+            },
+          ],
+        },
+      ]
+
+      ;(prismaMock.articleSection.findMany as jest.Mock).mockResolvedValue(mockData)
+
+      const result = await sectionService.getUserSectionStats(1)
+
+      expect(result).toEqual([
+        {
+          sectionId: 1,
+          sectionName: 'politics',
+          preference: 3,
+          behaviorScore: 1, // 단일 섹션이므로 정규화하지 않고 Default 1
+        },
+      ])
     })
   })
 })

--- a/server/src/services/sectionService.ts
+++ b/server/src/services/sectionService.ts
@@ -129,7 +129,23 @@ export const sectionService = {
       }
     })
 
-    return sectionScores.map((score) => ({
+    const rawBehaviorScores = sectionScores.map((s) => s.behaviorScore)
+    const minBehaviorScores = Math.min(...rawBehaviorScores)
+    const maxBehaviorScores = Math.max(...rawBehaviorScores)
+
+    // 행동 점수를 1에서 3 사이로 정규화
+    const normalizedScores = sectionScores.map((s) => {
+      let normalized = 1
+      if (maxBehaviorScores !== minBehaviorScores) {
+        normalized = 1 + ((s.behaviorScore - minBehaviorScores) / (maxBehaviorScores - minBehaviorScores)) * (3 - 1)
+      }
+      return {
+        ...s,
+        behaviorScore: parseFloat(normalized.toFixed(2)),
+      }
+    })
+
+    return normalizedScores.map((score) => ({
       sectionId: score.sectionId,
       sectionName: score.sectionName,
       preference: score.preference,


### PR DESCRIPTION
# Changelog
- 사용자의 행동 점수를  1점-3점 사이로 정규화하였습니다.

# Testing
- 유닛테스트 통과
<img width="745" height="1024" alt="image" src="https://github.com/user-attachments/assets/ed3c4b2e-a018-484f-8ad7-3f285ad90974" />

# Ops Impact
N/A

# Version Compatibility
N/A