### PR TITLE
[Terraform] 영역별 선호도 업데이트 안되는 버그 수정

### DIFF
--- a/terraform/server.tf
+++ b/terraform/server.tf
@@ -140,3 +140,9 @@ resource "google_project_iam_member" "server_bigquery_editor" {
   role    = "roles/bigquery.dataEditor"
   member  = google_service_account.server.member
 }
+
+resource "google_project_iam_member" "server_cloud_run_invoker" {
+  project = var.project
+  role    = "roles/run.invoker"
+  member  = google_service_account.server.member
+}


### PR DESCRIPTION
# Changelog
- 로컬에서 테스트할 때와 다르게 Cloud Run에 서버를 배포하면서, 해당 Cloud Run의 Service Account에 Cloud Function을 호출할 수 있는 권한을 부여하지 않았습니다.
- 따라서 영역별 선호도를 업데이트 할 때 Cloud Function을 호출하는 데에 문제가 발생하여 500 에러가 발생하였습니다.
- Cloud Run의 Service Account에 `roles/run.invoker`를 추가하여 Cloud Function을 호출할 권한을 추가하였습니다.

# Testing
- 권한 부여 후 서버에 영역별 선호도 업데이트 요청 테스트
<img width="917" height="882" alt="image" src="https://github.com/user-attachments/assets/9646e8b8-8c0c-4496-9c1c-c66d8b1e02fc" />

# Ops Impact
N/A

# Version Compatibility
N/A