### PR TITLE
[Server] 추천 뉴스가 선호도대로 반환되지 않는 오류 수정

### DIFF
--- a/server/src/services/__tests__/articleService.test.ts
+++ b/server/src/services/__tests__/articleService.test.ts
@@ -407,6 +407,25 @@ describe('ArticleService', () => {
 
       expect(result[0].region).toBe(undefined)
     })
+
+    it('Should return articles in the same order as the input IDs', async () => {
+      // Arrange
+      const userId = 1 // 1. 의도적으로 순서를 섞어서 ID 배열을 정의합니다.
+      const requestedIds = [3, 1, 2] // 2. 각 ID에 해당하는 mock 데이터를 생성합니다.
+
+      const mockArticle1 = { ...mockRawDetailedArticle, id: 1 }
+      const mockArticle2 = { ...mockRawDetailedArticle, id: 2 }
+      const mockArticle3 = { ...mockRawDetailedArticle, id: 3 } // 3. DB가 ID 순서대로(즉, 요청 순서와 다르게) 결과를 반환하는 상황을 시뮬레이션합니다.
+
+      ;(prismaMock.processedArticle.findMany as jest.Mock).mockResolvedValue([mockArticle1, mockArticle2, mockArticle3]) // Act
+
+      const result = await articleService.getDetailedArticlesByIds(requestedIds, userId) // Assert
+      // 4. 최종 결과에서 ID만 추출하여 원래 요청했던 ID 배열 순서와 일치하는지 확인합니다.
+
+      const resultIds = result.map((article) => article.id)
+      expect(resultIds).toEqual(requestedIds) // [3, 1, 2] 순서여야 합니다.
+      expect(result.length).toBe(3)
+    })
   })
 
   describe('getDetailedArticleById', () => {

--- a/server/src/services/articleService.ts
+++ b/server/src/services/articleService.ts
@@ -362,6 +362,7 @@ export const articleService = {
     }
 
     const allArticles = await articleService.getDetailedArticlesByIds(articleIds, userId)
+
     const articles = allArticles.slice(cursorIdx, cursorIdx + limit)
 
     if (articles.length === 0) {
@@ -403,8 +404,8 @@ export const articleService = {
   },
 
   /**
-   * 특정 ID의 기사들을 상세하게 조회합니다.
-   * 이 함수는 기사 ID 배열을 받아 해당 기사들의 상세 정보를 반환합니다.
+   * 특정 ID의 기사들을 상세하게 조회합니다. (순서 보장)
+   * 이 함수는 기사 ID 배열을 받아 해당 기사들의 상세 정보를 `ids`와 동일한 순서로 반환합니다.
    * @param ids - 조회할 기사 ID 배열
    * @param userId - 사용자의 ID (좋아요/스크랩 여부 확인용)
    * @return Promise<DetailedProcessedArticle[]> - 상세 기사 정보 배열
@@ -469,7 +470,12 @@ export const articleService = {
       },
     })
 
-    return articles.map((a) => ({
+    // 원본 `ids` 배열의 순서를 기준으로 정렬합니다.
+    // DB에 해당 ID의 기사가 없는 경우 undefined일 수 있으므로 필터링합니다.
+    const articleMap = new Map(articles.map((a) => [a.id, a]))
+    const sortedArticles = ids.map((id) => articleMap.get(id)).filter((a) => a !== undefined)
+
+    return sortedArticles.map((a) => ({
       id: a.id,
       section: {
         id: a.section.id,

--- a/terraform/news_fetchers.tf
+++ b/terraform/news_fetchers.tf
@@ -42,6 +42,7 @@ module "newsapi_fetcher" {
   runtime             = "python313"
   available_memory_mb = "256Mi"
   entry_point         = "main"
+  max_instance_count  = 20
   environment_variables = {
     "NEWSAPI_API_KEY"          = data.google_secret_manager_secret_version.newsapi_api.secret_data
     "INSTANCE_CONNECTION_NAME" = google_sql_database_instance.mysql.connection_name


### PR DESCRIPTION
# Changelog
기존에 사용자 선호도대로 Redis에 캐싱되어 있는 순서대로 반환되지 않는 오류가 있었습니다.
- `getDetailedArticlesByIds()` 에서 뉴스를 반환할 때, 패러미터 `ids` 의 순서대로 뉴스를 반환하도록 수정합니다.

# Testing
- 유닛테스트 통과
<img width="697" height="814" alt="image" src="https://github.com/user-attachments/assets/8014f596-4a83-4e6e-910a-1371aa8b4f1e" />

# Ops Impact
N/A

# Version Compatibility
N/A