### PR TITLE
[Server] 영역별 선호도가 재설정됐을 때 추천 뉴스 캐시 초기화

### DIFF
--- a/server/src/controllers/__tests__/userController.test.ts
+++ b/server/src/controllers/__tests__/userController.test.ts
@@ -11,11 +11,13 @@ import { AuthenticatedRequest } from '../../middlewares/authenticateJWT'
 import { Response } from 'express'
 import { sectionService } from '../../services/sectionService'
 import { keywordService } from '../../services/keywordService'
+import { articleService } from '../../services/articleService'
 
 jest.mock('../../utils/response')
 jest.mock('../../services/userService')
 jest.mock('../../services/sectionService')
 jest.mock('../../services/keywordService')
+jest.mock('../../services/articleService')
 
 let consoleErrorSpy: jest.SpyInstance
 
@@ -258,6 +260,7 @@ describe('updateUserSectionPreferences', () => {
 
     expect(userService.updateUserSectionPreferences).toHaveBeenCalledWith(1, preferences)
     expect(userService.requestUpdateUserEmbedding).toHaveBeenCalledWith(1)
+    expect(articleService.clearCachedRecommendations).toHaveBeenCalledWith(1)
     expect(success).toHaveBeenCalledWith(res, updatedPrefs, {
       message: 'User section preferences updated successfully',
     })

--- a/server/src/controllers/userController.ts
+++ b/server/src/controllers/userController.ts
@@ -5,6 +5,7 @@ import { AuthenticatedRequest } from '../middlewares/authenticateJWT'
 import { UserNotFoundError, userService } from '../services/userService'
 import { sectionService } from '../services/sectionService'
 import { keywordService } from '../services/keywordService'
+import { articleService } from '../services/articleService'
 
 /**
  * 사용자의 닉네임을 업데이트하는 컨트롤러입니다.
@@ -135,6 +136,9 @@ export const updateUserSectionPreferences = async (req: AuthenticatedRequest, re
 
     // 사용자 임베딩 벡터 업데이트 요청
     await userService.requestUpdateUserEmbedding(userId)
+
+    // 추천 캐시 초기화
+    await articleService.clearCachedRecommendations(userId)
 
     return success(res, updatedPrefs, {
       message: 'User section preferences updated successfully',

--- a/server/src/services/__tests__/articleService.test.ts
+++ b/server/src/services/__tests__/articleService.test.ts
@@ -16,6 +16,7 @@ jest.mock('../../config/redis', () => ({
   redisClient: {
     get: jest.fn(),
     setEx: jest.fn(),
+    del: jest.fn(),
   },
 }))
 
@@ -147,6 +148,16 @@ describe('ArticleService', () => {
       await expect(articleService.setCachedRecommendations(userId, mockCache)).rejects.toThrow(
         'Redis connection failed',
       )
+    })
+  })
+
+  describe('clearCachedRecommendations', () => {
+    it('Successfully clears cached recommendations for a user', async () => {
+      const userId = 1
+
+      await articleService.clearCachedRecommendations(userId)
+
+      expect(redisClient.del).toHaveBeenCalledWith(`recommendations:${userId}`)
     })
   })
 

--- a/server/src/services/articleService.ts
+++ b/server/src/services/articleService.ts
@@ -73,6 +73,20 @@ export const articleService = {
   },
 
   /**
+   * 사용자 ID에 해당하는 추천 기사를 캐시에서 삭제합니다.
+   * 이 함수는 Redis에서 추천 기사 정보를 제거합니다.
+   * @param userId - 추천 기사를 캐시에서 삭제할 사용자의 ID
+   * @return Promise<void> - 캐시 삭제가 완료되면 반환되는 프로미스
+   * @example
+   * // 사용자 1에 대한 추천 기사를 캐시에서 삭제
+   *  clearCachedRecommendations(1)
+   */
+  clearCachedRecommendations: async (userId: number): Promise<void> => {
+    const cacheKey = `recommendations:${userId}`
+    await redisClient.del(cacheKey)
+  },
+
+  /**
    * 사용자 임베딩과 후보 기사 임베딩을 비교하여 유사도를 계산하고, 유사도에 따라 기사를 정렬합니다.
    * 이 함수는 BigQuery에 쿼리를 실행하여 유사도를 계산합니다.
    * @param userId - 추천을 받을 사용자의 ID


### PR DESCRIPTION
# Changelog
영역별 선호도를 재설정했을 때, 새로운 선호도에 맞는 추천 뉴스가 뜨지 않는 문제가 발생하였습니다.
- 영역별 선호도를 재설정한 경우, 해당 사용자의 추천 뉴스 캐시를 초기화하도록 수정하였습니다.

# Testing
- 유닛테스트 통과
<img width="753" height="1190" alt="image" src="https://github.com/user-attachments/assets/bb7dcb8c-78e3-4cf9-8635-f24775960b56" />

# Ops Impact
N/A

# Version Compatibility
N/A