### PR TITLE
[Server] User Embedding이 없는 경우 FALLBACK 추천 뉴스 추가

### DIFF
--- a/server/src/services/__tests__/articleService.test.ts
+++ b/server/src/services/__tests__/articleService.test.ts
@@ -204,6 +204,18 @@ describe('ArticleService', () => {
         'BigQuery connection failed',
       )
     })
+
+    it('Return cadndiateArticles when no query result', async () => {
+      const userId = 1
+      const candidateArticleIds = [101, 102, 103]
+      const mockQueryResult: any[] = []
+
+      ;(bigqueryClient.query as jest.Mock).mockResolvedValue([mockQueryResult])
+
+      const result = await articleService.calculateSimilarityAndSort(userId, candidateArticleIds)
+
+      expect(result).toEqual(candidateArticleIds)
+    })
   })
 
   describe('getViewedArticleIdsByUser', () => {

--- a/server/src/services/articleService.ts
+++ b/server/src/services/articleService.ts
@@ -136,6 +136,9 @@ export const articleService = {
     }
 
     const [rows] = await bigqueryClient.query(options)
+    if (rows.length === 0) {
+      return candidateArticleIds // 결과 값이 없는 경우 Fallback으로 후보 기사 IDs를 반환합니다.
+    }
     const sortedArticleIds = (rows as ArticleSimilarityRow[]).map((row) => row.p_article_id)
     return sortedArticleIds
   },


### PR DESCRIPTION
# Changelog
- 모종의 이유로 User Embeddings가 BigQuery에 존재하지 않는 경우, `calculate_user_embeddings` Cloud Function이 실행되기 전까지 랜덤 뉴스를 추천합니다.

# Testing
- 유닛테스트 통과
<img width="724" height="954" alt="image" src="https://github.com/user-attachments/assets/64a4a005-a47c-4fe4-845a-92b99c521ef3" />

# Ops Impact
N/A

# Version Compatibility
N/A