### PR TITLE
[Server] Articles API에 원본 뉴스 제목 추가

### DIFF
--- a/server/src/services/__tests__/articleService.test.ts
+++ b/server/src/services/__tests__/articleService.test.ts
@@ -45,6 +45,7 @@ const mockRawDetailedArticle = {
         logo_url: 'https://example.com/logos/1.png',
       },
       news_url: 'https://news1.com/article/1',
+      title: 'Example News 1',
     },
     {
       provider: {
@@ -54,6 +55,7 @@ const mockRawDetailedArticle = {
         logo_url: 'https://example.com/logos/2.png',
       },
       news_url: 'https://news2.com/article/1',
+      title: 'Example News 2',
     },
   ],
   keywords: [
@@ -92,6 +94,7 @@ const mockDetailedArticle: DetailedProcessedArticle = {
     {
       id: 1,
       name: 'Test Provider',
+      title: 'Test News',
       friendlyName: '테스트 뉴스사',
       newsUrl: 'http://news1.com',
       logoUrl: 'http://logo1.com',
@@ -388,6 +391,7 @@ describe('ArticleService', () => {
           providers: mockRawDetailedArticle.articles.map((a) => ({
             id: a.provider.id,
             name: a.provider.name,
+            title: a.title,
             friendlyName: a.provider.friendly_name,
             newsUrl: a.news_url,
             logoUrl: a.provider.logo_url,

--- a/server/src/services/articleService.ts
+++ b/server/src/services/articleService.ts
@@ -454,6 +454,7 @@ export const articleService = {
               },
             },
             news_url: true,
+            title: true,
           },
         },
         keywords: {
@@ -501,6 +502,7 @@ export const articleService = {
       },
       providers: a.articles.map((art) => ({
         id: art.provider.id,
+        title: art.title,
         name: art.provider.name,
         friendlyName: art.provider.friendly_name,
         newsUrl: art.news_url,

--- a/server/src/swagger/openapi.yaml
+++ b/server/src/swagger/openapi.yaml
@@ -1332,6 +1332,9 @@ components:
         name:
           type: string
           example: 'Example News Provider'
+        title:
+          type: string
+          example: '원본 뉴스 제목'
         friendlyName:
           type: string
           example: '예시 뉴스 제공자'

--- a/server/src/types/article.ts
+++ b/server/src/types/article.ts
@@ -38,6 +38,7 @@ export interface ArticleSection {
 export interface ArticleProvider {
   id: number
   name: string
+  title: string
   friendlyName: string
   newsUrl: string
   logoUrl: string


### PR DESCRIPTION
# Changelog
- 원본 뉴스 보기 버튼을 클릭하면 뉴스사와 더불어 제목이 함께 보이도록 UI가 변경됨에 따라 Article API를 수정하였습니다.
- `getDetailedArticlesByIds()` 함수에 원본 뉴스의 title을 추가하였습니다.

# Testing
- Postman 테스트
<img width="850" height="742" alt="image" src="https://github.com/user-attachments/assets/7065c8ba-8b0f-45ff-8e7d-1ef890023932" />

- 유닛닛테스트
<img width="718" height="1008" alt="image" src="https://github.com/user-attachments/assets/31b5e13e-e075-4eae-9c3e-76330d2e1ecf" />

# Ops Impact
N/A

# Version Compatibility
N/A